### PR TITLE
Fix modal screens

### DIFF
--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -57,6 +57,15 @@ class AbstractEventLoop(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def register_signal_source(self, signal_source):
+        """Register source of signal for actual event queue.
+
+        :param signal_source: Source for future signals.
+        :type signal_source: `simpleline.render.ui_screen.UIScreen`
+        """
+        pass
+
+    @abstractmethod
     def enqueue_signal(self, signal):
         """Enqueue new event for processing.
 
@@ -68,6 +77,25 @@ class AbstractEventLoop(metaclass=ABCMeta):
     @abstractmethod
     def run(self):
         """Starts the event loop."""
+        pass
+
+    @abstractmethod
+    def execute_new_loop(self, signal):
+        """Starts the new event loop and pass `signal` in it.
+
+        This is required for processing a modal screens.
+
+        :param signal: signal passed to the new event loop
+        :type signal: `AbstractSignal` based class
+        """
+        pass
+
+    @abstractmethod
+    def close_loop(self):
+        """Close active event loop.
+
+        Close an event loop created by the `execute_new_loop()` method.
+        """
         pass
 
     @abstractmethod

--- a/simpleline/event_loop/event_queue.py
+++ b/simpleline/event_loop/event_queue.py
@@ -25,23 +25,53 @@ from simpleline import SimplelineError
 
 
 class EventQueueError(SimplelineError):
+    """Main exception for `EventQueue` class.
+
+    Inherits from `simpleline.SimplelineError`.
+    """
     pass
 
 
-# TODO: Document this
 class EventQueue(object):
+    """Class for managing signal queue.
+
+    Responsibilities of this class are:
+    * sorting by priority of signals
+    * managing sources for this event queue
+    * enqueuing signals
+    """
 
     def __init__(self):
         self._queue = PriorityQueue()
         self._contained_screens = set()
 
     def empty(self):
+        """Return true if Queue is empty.
+
+        :return: True if empty, False otherwise.
+        """
         return self._queue.empty()
 
     def enqueue(self, signal):
+        """Enqueue signal to this queue.
+
+        :param signal: Signal which should be enqueued to this queue.
+        :type signal: Signal class based on `simpleline.event_loop.signals.AbstractSignal`.
+        """
         self._queue.put(signal)
 
     def enqueue_if_source_belongs(self, signal, source):
+        """Enqueue signal to this queue if the signal source belongs to this queue.
+
+        Enqueue the `signal` only if the `source` belongs to this queue. See the `add_source()` method.
+
+        :param signal: Signal which should be enqueued to this queue.
+        :type signal: Signal class based on `simpleline.event_loop.signals.AbstractSignal`.
+        :param source: Source of this signal.
+        :type source: Anything.
+        :return: True if the source belongs to this queue and signal was queued, False otherwise.
+        :rtype: bool
+        """
         if self.contains_source(source):
             self._queue.put(signal)
             return True
@@ -49,16 +79,44 @@ class EventQueue(object):
             return False
 
     def get(self):
+        """Return enqueued signal with the highest priority.
+
+        This is FIFO implementation for the same priority.
+        If the queue is empty this method will wait for the input signal.
+
+        :return: Queued signal.
+        :rtype: Signal based on class `simpleline.event_loop.signals.AbstractSignal`.
+        """
         return self._queue.get()
 
     def add_source(self, signal_source):
+        """Add new source of signals to this queue.
+
+        This method is mandatory for `enqueue_if_source_belongs()` method.
+        The same source will be added only once.
+
+        :param signal_source: Source of future signals.
+        :type signal_source: Anything which will emit signals in future.
+        """
         self._contained_screens.add(signal_source)
 
     def remove_source(self, signal_source):
+        """Remove signal source from this queue.
+
+        :param signal_source: Source of future signals.
+        :type signal_source: Anything.
+        :raise: EventQueueError"""
         try:
             self._contained_screens.remove(signal_source)
         except KeyError:
             raise EventQueueError("Can't remove non-existing event source!")
 
     def contains_source(self, signal_source):
+        """Test if `signal_source` belongs to this queue.
+
+        :param signal_source: Source of signals.
+        :type signal_source: Anything.
+        :return: True if signal source belongs to this queue.
+        :rtype: bool
+        """
         return signal_source in self._contained_screens

--- a/simpleline/event_loop/event_queue.py
+++ b/simpleline/event_loop/event_queue.py
@@ -1,0 +1,64 @@
+# Default event queue for Simpleline application.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+
+
+from queue import PriorityQueue
+from simpleline import SimplelineError
+
+
+class EventQueueError(SimplelineError):
+    pass
+
+
+# TODO: Document this
+class EventQueue(object):
+
+    def __init__(self):
+        self._queue = PriorityQueue()
+        self._contained_screens = set()
+
+    def empty(self):
+        return self._queue.empty()
+
+    def enqueue(self, signal):
+        self._queue.put(signal)
+
+    def enqueue_if_source_belongs(self, signal, source):
+        if self.contains_source(source):
+            self._queue.put(signal)
+            return True
+        else:
+            return False
+
+    def get(self):
+        return self._queue.get()
+
+    def add_source(self, signal_source):
+        self._contained_screens.add(signal_source)
+
+    def remove_source(self, signal_source):
+        try:
+            self._contained_screens.remove(signal_source)
+        except KeyError:
+            raise EventQueueError("Can't remove non-existing event source!")
+
+    def contains_source(self, signal_source):
+        return signal_source in self._contained_screens

--- a/simpleline/render/renderer.py
+++ b/simpleline/render/renderer.py
@@ -211,14 +211,21 @@ class Renderer(object):
             # and skip the input processing once, to redisplay the screen first
             self.redraw()
         else:
-            # if redraw is needed, separate the content on the screen from the
-            # stuff we are about to display now
-            self._input_error_counter = 0
-            print(self._spacer)
+            # redraw is demanded
 
             # refresh the screen and print its content
             try:
+                # refresh screen content
                 input_required = top_screen.ui_screen.refresh(top_screen.args)
+
+                # Screen was closed in the refresh method
+                if top_screen != self._get_last_screen():
+                    return
+
+                # separate the content on the screen from the stuff we are about to display now
+                self._input_error_counter = 0
+                print(self._spacer)
+
                 top_screen.ui_screen.show_all()
                 if input_required:
                     self.input_required()

--- a/simpleline/render/renderer.py
+++ b/simpleline/render/renderer.py
@@ -115,13 +115,13 @@ class Renderer(object):
         :type args: anything
         """
         try:
-            should_draw_immediately = self._screen_stack.pop().draw_immediately
+            execute_new_loop = self._screen_stack.pop().execute_new_loop
         except ScreenStackEmptyException:
             raise ScreenStackEmptyException("Switch screen is not possible when there is no screen scheduled!")
 
         # we have to keep the old_loop value so we stop
         # dialog's mainloop if it ever uses switch_screen
-        screen = ScreenData(ui, args, should_draw_immediately)
+        screen = ScreenData(ui, args, execute_new_loop)
         self._screen_stack.append(screen)
         self.redraw()
 
@@ -152,7 +152,9 @@ class Renderer(object):
         """
         screen = ScreenData(ui, args, True)
         self._screen_stack.append(screen)
-        self._do_redraw()
+        # only new events will be processed now
+        # the old one will wait after this event loop will be closed
+        self._event_loop.execute_new_loop(RenderScreenSignal(self))
 
     def close_screen(self, closed_from=None):
         """Close the currently displayed screen and exit it's main loop if necessary.
@@ -164,14 +166,12 @@ class Renderer(object):
         # User can react when screen is closing
         screen.ui_screen.closed()
 
-        # this cannot happen, if we are closing the window,
-        # the loop must have been running or not be there at all
-        if screen.draw_immediately:
-            raise RendererUnexpectedError("New main loop is requested when closing window!")
-
         if closed_from is not None and closed_from is not screen.ui_screen:
             raise RendererUnexpectedError("You are trying to close screen %s from screen %s! "
                                           "This is most probably not intentional." % (closed_from, screen.ui_screen))
+
+        if screen.execute_new_loop:
+            self._event_loop.close_loop()
 
         if not self._screen_stack.empty():
             self.redraw()
@@ -200,40 +200,27 @@ class Renderer(object):
                 self.redraw()
                 return
 
-        # new mainloop is requested
-        if top_screen.draw_immediately:
-            # change the record to indicate mainloop is running
-            self._screen_stack.pop()
-            self.switch_screen(top_screen.ui_screen, top_screen.args)
-            # redraw this screen now
-            self._do_redraw()
-            # after the mainloop ends, set the redraw flag
-            # and skip the input processing once, to redisplay the screen first
-            self.redraw()
-        else:
-            # redraw is demanded
+        # get the widget tree from the screen and show it in the screen
+        try:
+            # refresh screen content
+            input_required = top_screen.ui_screen.refresh(top_screen.args)
 
-            # refresh the screen and print its content
-            try:
-                # refresh screen content
-                input_required = top_screen.ui_screen.refresh(top_screen.args)
+            # Screen was closed in the refresh method
+            if top_screen != self._get_last_screen():
+                return
 
-                # Screen was closed in the refresh method
-                if top_screen != self._get_last_screen():
-                    return
+            # separate the content on the screen from the stuff we are about to display now
+            self._input_error_counter = 0
+            print(self._spacer)
 
-                # separate the content on the screen from the stuff we are about to display now
-                self._input_error_counter = 0
-                print(self._spacer)
-
-                top_screen.ui_screen.show_all()
-                if input_required:
-                    self.input_required()
-            except ExitMainLoop:
-                raise
-            except Exception:    # pylint: disable=broad-except
-                self._event_loop.enqueue_signal(ExceptionSignal(self))
-                return False
+            top_screen.ui_screen.show_all()
+            if input_required:
+                self.input_required()
+        except ExitMainLoop:
+            raise
+        except Exception:    # pylint: disable=broad-except
+            self._event_loop.enqueue_signal(ExceptionSignal(self))
+            return False
 
     def _get_last_screen(self):
         if self._screen_stack.empty():

--- a/simpleline/render/screen_stack.py
+++ b/simpleline/render/screen_stack.py
@@ -60,17 +60,17 @@ class ScreenStack(object):
 
 class ScreenData(object):
 
-    def __init__(self, ui_screen, args=None, draw_immediately=False):
+    def __init__(self, ui_screen, args=None, execute_new_loop=False):
         self.ui_screen = ui_screen
         if args is None:
             self.args = []
         else:
             self.args = args
-        self.draw_immediately = draw_immediately
+        self.execute_new_loop = execute_new_loop
 
     def __str__(self):
         msg = self.__class__.__name__
         msg += "("
-        msg += ",".join((str(self.ui_screen), str(self.args), str(self.draw_immediately)))
+        msg += ",".join((str(self.ui_screen), str(self.args), str(self.execute_new_loop)))
         msg += ")"
         return msg

--- a/simpleline/render/screen_stack.py
+++ b/simpleline/render/screen_stack.py
@@ -24,28 +24,50 @@ from simpleline import SimplelineError
 
 
 class ScreenStackException(SimplelineError):
+    """General screen stack exception."""
     pass
 
 
 class ScreenStackEmptyException(ScreenStackException):
+    """Screen stack exception when stack is empty."""
     pass
 
 
 class ScreenStack(object):
+    """Managing screen stack used in `Renderer`."""
 
     def __init__(self):
         self._screens = []
 
     def empty(self):
+        """Test if screen stack is empty.
+
+        :return: True if empty.
+        :rtype: bool
+        """
         return not self._screens
 
     def size(self):
+        """Get size of the stack.
+
+        :return: Size of the stack.
+        """
         return len(self._screens)
 
-    def append(self, screen_item):
-        self._screens.append(screen_item)
+    def append(self, screen):
+        """Add new screen to the top of the stack.
+
+        :param screen: Screen for the future rendering.
+        :type screen: Class based on `simpleline.render.ui_screen.UIScreen`.
+        """
+        self._screens.append(screen)
 
     def pop(self, remove=True):
+        """Return top item from the stack.
+
+        :param remove: If True (default) also remove this items from the stack.
+        :return: The top screen on the stack.
+        """
         try:
             if remove:
                 return self._screens.pop()
@@ -55,10 +77,16 @@ class ScreenStack(object):
             raise ScreenStackEmptyException(e)
 
     def add_first(self, screen):
+        """Add `screen` to the bottom of the stack.
+
+        :param screen: Add the `screen` to the bottom of the stack.
+        :type screen: Class based on `simpleline.render.ui_screen.UIScreen`.
+        """
         self._screens.insert(0, screen)
 
 
 class ScreenData(object):
+    """Inner data class to store screen data."""
 
     def __init__(self, ui_screen, args=None, execute_new_loop=False):
         self.ui_screen = ui_screen

--- a/simpleline/render/ui_screen.py
+++ b/simpleline/render/ui_screen.py
@@ -62,6 +62,7 @@ class UIScreen(SignalHandler):
         :rtype: bool
         """
         self._ready = True
+        App.event_loop().register_signal_source(self)
         return True
 
     def refresh(self, args=None):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@
 from simpleline.base import App
 
 
-def calculate_separator(width):
+def calculate_separator(width=80):
     separator = "\n".join(2 * [width * "="])
     separator += "\n"  # print adds another newline
     return separator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,33 @@
+# Helper functions for the test classes.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from simpleline.base import App
+
+
+def calculate_separator(width):
+    separator = "\n".join(2 * [width * "="])
+    separator += "\n"  # print adds another newline
+    return separator
+
+
+def schedule_screen_and_run(screen):
+    App.initialize()
+    App.renderer().schedule_screen(screen)
+    App.run()
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,15 @@ def calculate_separator(width=80):
     return separator
 
 
+def create_output_with_separators(screens_text):
+    msg = ""
+    for screen_txt in screens_text:
+        msg += calculate_separator()
+        msg += screen_txt + "\n\n"
+
+    return msg
+
+
 def schedule_screen_and_run(screen):
     App.initialize()
     App.renderer().schedule_screen(screen)

--- a/tests/event_queue_test.py
+++ b/tests/event_queue_test.py
@@ -1,0 +1,102 @@
+# Event queue test classes.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+
+import unittest
+from unittest.mock import MagicMock
+from simpleline.event_loop.event_queue import EventQueue, EventQueueError
+from simpleline.event_loop.signals import AbstractSignal
+
+
+class EventQueue_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.e = EventQueue()
+
+    def test_queue_is_empty(self):
+        self.assertTrue(self.e.empty())
+
+    def test_enqueue(self):
+        fake_signal = MagicMock()
+
+        self.e.enqueue(fake_signal)
+        self.assertFalse(self.e.empty())
+
+        self.assertEqual(fake_signal, self.e.get())
+        self.assertTrue(self.e.empty())
+
+    def test_enqueue_priority(self):
+        signal_low_priority = TestSignal(priority=10)
+        signal_high_priority = TestSignal(priority=0)
+
+        self.e.enqueue(signal_low_priority)
+        self.e.enqueue(signal_high_priority)
+
+        self.assertEqual(signal_high_priority, self.e.get())
+        self.assertEqual(signal_low_priority, self.e.get())
+
+        # Test adding signals in different order (result shouldn't change)
+        self.e.enqueue(signal_high_priority)
+        self.e.enqueue(signal_low_priority)
+
+        self.assertEqual(signal_high_priority, self.e.get())
+        self.assertEqual(signal_low_priority, self.e.get())
+
+    def test_adding_event_source(self):
+        fake_source = MagicMock()
+        self.e.add_source(fake_source)
+
+        self.assertTrue(self.e.contains_source(fake_source))
+
+    def test_removing_event_source(self):
+        fake_source = MagicMock()
+        self.e.add_source(fake_source)
+
+        self.e.remove_source(fake_source)
+
+        self.assertFalse(self.e.contains_source(fake_source))
+
+    def test_remove_empty_source(self):
+        with self.assertRaises(EventQueueError):
+            self.e.remove_source(MagicMock())
+
+    def test_enqueue_if_source_belongs(self):
+        source = MagicMock()
+        signal = TestSignal(source=source)
+
+        self.e.add_source(source)
+        self.assertTrue(self.e.enqueue_if_source_belongs(signal, source))
+        self.assertEqual(signal, self.e.get())
+
+    def test_enqueue_if_source_does_not_belong(self):
+        signal = TestSignal()
+        signal_low_priority = TestSignal(priority=25)
+
+        # the get method will wait if nothing present so adding low priority signal below give us check if the queue
+        # is really empty
+        self.e.enqueue(signal_low_priority)
+
+        self.assertFalse(self.e.enqueue_if_source_belongs(signal, MagicMock()))
+        self.assertEqual(signal_low_priority, self.e.get())
+
+
+class TestSignal(AbstractSignal):
+
+    def __init__(self, source=None, priority=20):
+        super().__init__(source, priority)

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -25,18 +25,7 @@ from io import StringIO
 from simpleline.base import App
 from simpleline.render.ui_screen import UIScreen
 from simpleline.render import INPUT_PROCESSED, INPUT_DISCARDED, RendererUnexpectedError
-
-
-def _calculate_separator(width):
-    separator = "\n".join(2 * [width * "="])
-    separator += "\n"  # print adds another newline
-    return separator
-
-
-def _schedule_screen_and_run(screen):
-    App.initialize()
-    App.renderer().schedule_screen(screen)
-    App.run()
+from tests import schedule_screen_and_run, calculate_separator
 
 
 def _fake_input(queue_instance, prompt, hidden):
@@ -49,9 +38,9 @@ class SeparatorPrinting_TestCase(unittest.TestCase):
     def test_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
 
-        _schedule_screen_and_run(ui_screen)
+        schedule_screen_and_run(ui_screen)
 
-        self.assertEqual(stdout_mock.getvalue(), _calculate_separator(80))
+        self.assertEqual(stdout_mock.getvalue(), calculate_separator(80))
 
     def test_other_width_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
@@ -62,7 +51,7 @@ class SeparatorPrinting_TestCase(unittest.TestCase):
         App.renderer().schedule_screen(ui_screen)
         App.run()
 
-        self.assertEqual(stdout_mock.getvalue(), _calculate_separator(width))
+        self.assertEqual(stdout_mock.getvalue(), calculate_separator(width))
 
     def test_no_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
@@ -107,12 +96,12 @@ class SimpleUIScreenFeatures_TestCase(unittest.TestCase):
 class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
 
     def setUp(self):
-        self._default_separator = _calculate_separator(80)
+        self._default_separator = calculate_separator(80)
 
     def test_screen_event_loop_processing(self, _):
         ui_screen = EmptyScreen()
 
-        _schedule_screen_and_run(ui_screen)
+        schedule_screen_and_run(ui_screen)
 
         self.assertTrue(ui_screen.is_closed)
 
@@ -136,7 +125,7 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
         screen = NoInputScreen()
         screen.title = u"TestTitle"
 
-        _schedule_screen_and_run(screen)
+        schedule_screen_and_run(screen)
 
         out = self._default_separator
         out += "TestTitle\n\n"
@@ -147,72 +136,9 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
         input_mock.return_value = "a"
         screen = InputScreen()
 
-        _schedule_screen_and_run(screen)
+        schedule_screen_and_run(screen)
 
         self.assertTrue(screen.input_processed)
-
-
-@mock.patch('sys.stdout', new_callable=StringIO)
-class ScreenScheduler_TestCase(unittest.TestCase):
-
-    def test_replace_screen(self, _):
-        replace_screen = ShowedCounterScreen()
-        screen = ShowedCounterScreen(replace_screen=replace_screen)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.counter, 1)
-        self.assertEqual(replace_screen.counter, 1)
-
-    def test_switch_screen(self, _):
-        switched_screen = ShowedCounterScreen()
-        screen = ShowedCounterScreen(switched_screen)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.counter, 2)
-        self.assertEqual(switched_screen.counter, 1)
-
-    def test_switch_screen_modal_in_render(self, _):
-        modal_screen = ModalTestScreen()
-        screen = ModalTestScreen(modal_screen_render=modal_screen)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
-        self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
-
-    def test_switch_screen_modal_in_refresh(self, _):
-        modal_screen = ModalTestScreen()
-        screen = ModalTestScreen(modal_screen_refresh=modal_screen)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_REFRESH)
-        self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_REFRESH)
-
-    def test_switch_screen_modal_refresh_and_render(self, _):
-        modal_refresh = ModalTestScreen()
-        modal_render = ModalTestScreen()
-        screen = ModalTestScreen(modal_screen_refresh=modal_refresh, modal_screen_render=modal_render)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
-        self.assertEqual(modal_refresh.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_REFRESH)
-        self.assertEqual(modal_render.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
-
-    def test_switch_screen_modal_render_recursive(self, _):
-        modal_render_inner = ModalTestScreen()
-        modal_render_outer = ModalTestScreen(modal_screen_render=modal_render_inner)
-        screen = ModalTestScreen(modal_screen_render=modal_render_outer)
-
-        _schedule_screen_and_run(screen)
-
-        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
-        # outer modal screen has AFTER_MODAL_START_RENDER because it was set before by inner loop
-        self.assertEqual(modal_render_outer.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
-        self.assertEqual(modal_render_inner.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
@@ -222,13 +148,13 @@ class ScreenException_TestCase(unittest.TestCase):
         screen = ExceptionTestScreen(ExceptionTestScreen.REFRESH)
 
         with self.assertRaises(TestRefreshException):
-            _schedule_screen_and_run(screen)
+            schedule_screen_and_run(screen)
 
     def test_raise_exception_in_rendering(self, _):
         screen = ExceptionTestScreen(ExceptionTestScreen.REDRAW)
 
         with self.assertRaises(TestRedrawException):
-            _schedule_screen_and_run(screen)
+            schedule_screen_and_run(screen)
 
 
 @mock.patch('sys.stdout')
@@ -367,76 +293,6 @@ class InputScreen(UIScreen):
             self.input_processed = True
         self.close()
         return INPUT_PROCESSED
-
-
-class ShowedCounterScreen(UIScreen):
-
-    def __init__(self, switch_to_screen=None, replace_screen=None):
-        super().__init__()
-        self._switch_to_screen = switch_to_screen
-        self._replace_screen = replace_screen
-        self.counter = 0
-
-    def refresh(self, args=None):
-        super().refresh(args)
-        return False
-
-    def show_all(self):
-        super().show_all()
-        self.counter += 1
-        if self._switch_to_screen is not None:
-            App.renderer().switch_screen(self._switch_to_screen)
-            self._switch_to_screen = None
-        elif self._replace_screen is not None:
-            App.renderer().replace_screen(self._replace_screen)
-            self._replace_screen = None
-        else:
-            self.close()
-
-
-class ModalTestScreen(UIScreen):
-    """Test if the modal screen is really modal and stops the execution in a place where we start the modal screen.
-
-    This class have checkpoints which increment class variable counter. This counter is copied in the modal instance
-    to the local variable self.copied_modal_counter.
-    In the end we should check if the instance modal counter have the correct value, which is before the
-    modal screen was started (1).
-    """
-
-    INIT = 0
-    BEFORE_MODAL_START_REFRESH = 1
-    AFTER_MODAL_START_REFRESH = 2
-    BEFORE_MODAL_START_RENDER = 3
-    AFTER_MODAL_START_RENDER = 4
-
-    modal_counter = 0
-
-    def __init__(self, modal_screen_render=None, modal_screen_refresh=None):
-        super().__init__()
-        self._modal_screen_render = modal_screen_render
-        self._modal_screen_refresh = modal_screen_refresh
-        self.copied_modal_counter = 0
-        ModalTestScreen.modal_counter = self.INIT
-
-    def refresh(self, args=None):
-        super().refresh(args)
-        if self._modal_screen_refresh is not None:
-            # Start a new modal screen
-            ModalTestScreen.modal_counter = self.BEFORE_MODAL_START_REFRESH
-            App.renderer().switch_screen_modal(self._modal_screen_refresh)
-            ModalTestScreen.modal_counter = self.AFTER_MODAL_START_REFRESH
-        return False
-
-    def show_all(self):
-        super().show_all()
-        if self._modal_screen_render is not None:
-            # Start new modal screen
-            ModalTestScreen.modal_counter = self.BEFORE_MODAL_START_RENDER
-            App.renderer().switch_screen_modal(self._modal_screen_render)
-            ModalTestScreen.modal_counter = self.AFTER_MODAL_START_RENDER
-
-        self.copied_modal_counter = ModalTestScreen.modal_counter
-        self.close()
 
 
 class ExceptionTestScreen(UIScreen):

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -36,7 +36,7 @@ class Renderer_TestCase(unittest.TestCase):
 
     def create_renderer_with_stack(self):
         self.stack = ScreenStack()
-        self.renderer = Renderer(event_loop=MainLoop(), renderer_stack=self.stack)
+        self.renderer = Renderer(event_loop=mock.MagicMock(), renderer_stack=self.stack)
 
     def pop_last_item(self, remove=True):
         return self.stack.pop(remove)
@@ -76,8 +76,8 @@ class Renderer_TestCase(unittest.TestCase):
         self.renderer.schedule_screen(screen)
         test_screen = self.pop_last_item(False)
         self.assertEqual(test_screen.ui_screen, screen)
-        self.assertEqual(len(test_screen.args), 0) # empty field - no arguments
-        self.assertFalse(test_screen.draw_immediately)
+        self.assertEqual(len(test_screen.args), 0)  # empty field - no arguments
+        self.assertFalse(test_screen.execute_new_loop)
 
         # Schedule another screen, new one will be added to the bottom of the stack
         new_screen = UIScreen()
@@ -140,7 +140,7 @@ class Renderer_TestCase(unittest.TestCase):
         test_screen = self.pop_last_item()
         self.assertEqual(test_screen.ui_screen, new_screen)
         self.assertEqual(test_screen.args, [])
-        self.assertEqual(test_screen.draw_immediately, False)
+        self.assertEqual(test_screen.execute_new_loop, False)
 
         # We popped the new_screen so the old screen should stay here
         self.assertEqual(self.pop_last_item().ui_screen, screen)
@@ -174,7 +174,7 @@ class Renderer_TestCase(unittest.TestCase):
         test_screen = self.pop_last_item()
         self.assertEqual(test_screen.ui_screen, new_screen)
         self.assertEqual(test_screen.args, [])
-        self.assertEqual(test_screen.draw_immediately, True)
+        self.assertEqual(test_screen.execute_new_loop, True)
 
     @mock.patch('simpleline.render.renderer.Renderer._do_redraw')
     def test_switch_screen_modal_with_args(self, _):

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -30,8 +30,6 @@ from simpleline.render.ui_screen import UIScreen
 
 class Renderer_TestCase(unittest.TestCase):
 
-    DO_NOT_TEST = "DO_NOT_TEST"
-
     def setUp(self):
         self.stack = None
         self.renderer = None

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -1,0 +1,158 @@
+# Screen scheduling test classes.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import unittest
+from unittest import mock
+from io import StringIO
+from simpleline.base import App
+from simpleline.render.ui_screen import UIScreen
+from tests import schedule_screen_and_run
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+class ScreenScheduler_TestCase(unittest.TestCase):
+
+    def test_replace_screen(self, _):
+        replace_screen = ShowedCounterScreen()
+        screen = ShowedCounterScreen(replace_screen=replace_screen)
+
+        schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.counter, 1)
+        self.assertEqual(replace_screen.counter, 1)
+
+    def test_switch_screen(self, _):
+        switched_screen = ShowedCounterScreen()
+        screen = ShowedCounterScreen(switched_screen)
+
+        schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.counter, 2)
+        self.assertEqual(switched_screen.counter, 1)
+
+    def test_switch_screen_modal_in_render(self, _):
+        modal_screen = ModalTestScreen()
+        screen = ModalTestScreen(modal_screen_render=modal_screen)
+
+        schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
+        self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
+
+    def test_switch_screen_modal_in_refresh(self, _):
+        modal_screen = ModalTestScreen()
+        screen = ModalTestScreen(modal_screen_refresh=modal_screen)
+
+        schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_REFRESH)
+        self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_REFRESH)
+
+    def test_switch_screen_modal_refresh_and_render(self, _):
+        modal_refresh = ModalTestScreen()
+        modal_render = ModalTestScreen()
+        screen = ModalTestScreen(modal_screen_refresh=modal_refresh, modal_screen_render=modal_render)
+
+        schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
+        self.assertEqual(modal_refresh.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_REFRESH)
+        self.assertEqual(modal_render.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
+
+    def test_switch_screen_modal_render_recursive(self, _):
+        modal_render_inner = ModalTestScreen()
+        modal_render_outer = ModalTestScreen(modal_screen_render=modal_render_inner)
+        screen = ModalTestScreen(modal_screen_render=modal_render_outer)
+
+        _schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
+        # outer modal screen has AFTER_MODAL_START_RENDER because it was set before by inner loop
+        self.assertEqual(modal_render_outer.copied_modal_counter, ModalTestScreen.AFTER_MODAL_START_RENDER)
+        self.assertEqual(modal_render_inner.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_START_RENDER)
+
+
+class ShowedCounterScreen(UIScreen):
+
+    def __init__(self, switch_to_screen=None, replace_screen=None):
+        super().__init__()
+        self._switch_to_screen = switch_to_screen
+        self._replace_screen = replace_screen
+        self.counter = 0
+
+    def refresh(self, args=None):
+        super().refresh(args)
+        return False
+
+    def show_all(self):
+        super().show_all()
+        self.counter += 1
+        if self._switch_to_screen is not None:
+            App.renderer().switch_screen(self._switch_to_screen)
+            self._switch_to_screen = None
+        elif self._replace_screen is not None:
+            App.renderer().replace_screen(self._replace_screen)
+            self._replace_screen = None
+        else:
+            self.close()
+
+
+class ModalTestScreen(UIScreen):
+    """Test if the modal screen is really modal and stops the execution in a place where we start the modal screen.
+
+    This class have checkpoints which increment class variable counter. This counter is copied in the modal instance
+    to the local variable self.copied_modal_counter.
+    In the end we should check if the instance modal counter have the correct value, which is before the
+    modal screen was started (1).
+    """
+
+    INIT = 0
+    BEFORE_MODAL_START_REFRESH = 1
+    AFTER_MODAL_START_REFRESH = 2
+    BEFORE_MODAL_START_RENDER = 3
+    AFTER_MODAL_START_RENDER = 4
+
+    modal_counter = 0
+
+    def __init__(self, modal_screen_render=None, modal_screen_refresh=None):
+        super().__init__()
+        self._modal_screen_render = modal_screen_render
+        self._modal_screen_refresh = modal_screen_refresh
+        self.copied_modal_counter = 0
+        ModalTestScreen.modal_counter = self.INIT
+
+    def refresh(self, args=None):
+        super().refresh(args)
+        if self._modal_screen_refresh is not None:
+            # Start a new modal screen
+            ModalTestScreen.modal_counter = self.BEFORE_MODAL_START_REFRESH
+            App.renderer().switch_screen_modal(self._modal_screen_refresh)
+            ModalTestScreen.modal_counter = self.AFTER_MODAL_START_REFRESH
+        return False
+
+    def show_all(self):
+        super().show_all()
+        if self._modal_screen_render is not None:
+            # Start new modal screen
+            ModalTestScreen.modal_counter = self.BEFORE_MODAL_START_RENDER
+            App.renderer().switch_screen_modal(self._modal_screen_render)
+            ModalTestScreen.modal_counter = self.AFTER_MODAL_START_RENDER
+
+        self.copied_modal_counter = ModalTestScreen.modal_counter
+        self.close()

--- a/tests/screen_stack_test.py
+++ b/tests/screen_stack_test.py
@@ -109,11 +109,11 @@ class ScreenData_TestCase(unittest.TestCase):
     def _prepare(self):
         self.ui_screen = UIScreen()
 
-    def _screen_check(self, test_screen, ui_screen, args, draw_immediately):
+    def _screen_check(self, test_screen, ui_screen, args, execute_new_loop):
         self._prepare()
         self.assertEqual(test_screen.ui_screen, ui_screen)
         self.assertEqual(test_screen.args, args)
-        self.assertEqual(test_screen.draw_immediately, draw_immediately)
+        self.assertEqual(test_screen.execute_new_loop, execute_new_loop)
 
     def test_screen_data(self):
         self._prepare()
@@ -131,10 +131,10 @@ class ScreenData_TestCase(unittest.TestCase):
 
     def test_screen_data_with_execute_loop(self):
         self._prepare()
-        screen = ScreenData(self.ui_screen, draw_immediately=True)
+        screen = ScreenData(self.ui_screen, execute_new_loop=True)
         self._screen_check(screen, self.ui_screen, [], True)
 
-        screen2 = ScreenData(self.ui_screen, draw_immediately=False)
+        screen2 = ScreenData(self.ui_screen, execute_new_loop=False)
         self._screen_check(screen2, self.ui_screen, [], False)
 
     def test_screen_data_with_args_and_execute_loop(self):


### PR DESCRIPTION
Modal screens needs their own event loop. So execute a new loop for every modal screen. Also manage to which source belongs to which event queue.

This means that modal window will delay even the future signals from the old screens. Every new signal emitted from old screens will be add to the old (non-active) event loop. These signals will be processed after the modal window will be closed.