### PR TITLE
Add widget containers

### DIFF
--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -10,7 +10,8 @@ class HelloWorld(UIScreen):
 
     def refresh(self, args=None):
         super().refresh()
-        self.window = [TextWidget("Hello World")]
+        self.window.add(TextWidget("Hello World"))
+        self.window.add_separator()
 
 
 if __name__ == "__main__":

--- a/examples/entry_counter/entry_counter.py
+++ b/examples/entry_counter/entry_counter.py
@@ -7,10 +7,9 @@ from simpleline.render.widgets import TextWidget, CenterWidget
 
 
 class Hub(UIScreen):
-    title = u"Hub for entry counter"
 
     def __init__(self):
-        super().__init__()
+        super().__init__("Hub for entry counter")
         self._counter_spoke = CounterScreen()
 
     def refresh(self, args=None):
@@ -18,7 +17,8 @@ class Hub(UIScreen):
 
         w = CenterWidget(TextWidget("Press '1' to enter Entry counter"))
 
-        self.window += [w, ""]
+        self.window.add(w)
+        self.window.add_separator()
 
     def input(self, args, key):
         """Run spokes based on the user choice"""
@@ -36,10 +36,9 @@ class Hub(UIScreen):
 
 
 class CounterScreen(UIScreen):
-    title = u"Counter Screen"
 
     def __init__(self):
-        super().__init__()
+        super().__init__("Counter Screen")
         self._counter = 0
 
     def closed(self):
@@ -54,7 +53,7 @@ class CounterScreen(UIScreen):
         """Write message to user"""
         super().refresh(args)
         w = TextWidget("Counter {}".format(self._counter))
-        self.window += [CenterWidget(w), ""]
+        self.window.add(CenterWidget(w), "")
 
     @property
     def counter(self):

--- a/examples/hub_spoke/hub_spoke.py
+++ b/examples/hub_spoke/hub_spoke.py
@@ -9,14 +9,13 @@ from simpleline.render.widgets import TextWidget, ColumnWidget, CenterWidget
 
 
 class Hub(UIScreen):
-    title = u"Hub"
 
     KEY_USER = "1"
     KEY_SURNAME = "2"
     KEY_PASSWORD = "3"
 
     def __init__(self):
-        super().__init__()
+        super().__init__("Hub")
         self._name_spoke = SetNameScreen("First name", "John")
         self._surname_spoke = SetNameScreen("Surname", "Doe")
         self._pass_spoke = PasswordDialog()
@@ -26,6 +25,7 @@ class Hub(UIScreen):
 
         header = TextWidget("Please complete all the spokes to continue")
         header = CenterWidget(header)
+        self.window.add(header)
 
         left = [TextWidget("{}) First name".format(self.KEY_USER)),
                 TextWidget("   {}".format(self._name_spoke.value)),
@@ -37,7 +37,9 @@ class Hub(UIScreen):
             right.append(TextWidget("   Password is set"))
 
         col = ColumnWidget([(30, left), (30, right)], 5)
-        self.window += [header, "", "", col, ""]
+        self.window.add_separator(2)
+        self.window.add(col)
+        self.window.add_separator()
 
     def input(self, args, key):
         """Run spokes based on the user choice."""
@@ -76,12 +78,11 @@ class SetNameScreen(UIScreen):
         """Write message to user."""
         super().refresh(args)
         w = TextWidget(self._message)
-        self.window += [CenterWidget(w), ""]
-        return True
+        self.window.add(CenterWidget(w))
 
     def prompt(self, args=None):
         """Take user input."""
-        self._value = App.get_scheduler().raw_input("Write your name: ")
+        self._value = self.get_user_input("Write your name: ")
         self.close()
 
     @property

--- a/examples/ignore_continue/ignore_continue.py
+++ b/examples/ignore_continue/ignore_continue.py
@@ -13,17 +13,16 @@ class MyApp(App):
 
 
 class InfiniteScreen(UIScreen):
-    title = u"You need to use 'q' to quit"
 
     def __init__(self):
-        super().__init__()
+        super().__init__("You need to use 'q' to quit")
         self.continue_count = 0
 
     def refresh(self, args=None):
         """Print text to user with number of continue clicked"""
         super().refresh(args)
         text = TextWidget("You pressed {} times on continue".format(self.continue_count))
-        self.window += [CenterWidget(text), ""]
+        self.window.add(CenterWidget(text))
 
     def input(self, args, key):
         """Catch 'c' keys for continue and increase counter"""

--- a/simpleline/base.py
+++ b/simpleline/base.py
@@ -28,6 +28,9 @@ __all__ = ["App"]
 class App(object):
     """This is the main class for Simpleline library.
 
+    Do not create instance of this class. Use this class as static!
+    The `initialize()` method must be called before use.
+
     It is giving you access to the scheduler and event loop. You can have only one instance of this
     class in your application.
 
@@ -41,13 +44,6 @@ class App(object):
         def __init__(self, scheduler, event_loop):
             self.event_loop = event_loop
             self.scheduler = scheduler
-
-    def __init__(self):
-        """Do not create instance of this class. Use this class as static.
-
-        The `initialize()` method must be called before use.
-        """
-        super().__init__()
 
     @classmethod
     def initialize(cls, scheduler=None, event_loop=None):

--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -99,14 +99,14 @@ class AbstractEventLoop(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def process_signals(self, return_at=None):
+    def process_signals(self, return_after=None):
         """Processes incoming async messages and returns when a specific message is encountered
         or when the queue_instance is empty.
 
-        :param return_at: If return_at message was specified, the received message is returned.
-        :type return_at: Value returned by `Event.id`.
+        :param return_after: If `return_after` message was specified, the received message is returned.
+        :type return_after: Value returned by `Event.id`.
 
-        If the message does not fit return_at, but handlers are defined then it processes all handlers for
+        If the message does not fit `return_after`, but handlers are defined then it processes all handlers for
         this message.
         """
         pass

--- a/simpleline/event_loop/signals.py
+++ b/simpleline/event_loop/signals.py
@@ -48,9 +48,7 @@ class ExceptionSignal(AbstractSignal):
 
 class InputReadySignal(AbstractSignal):
     """Input from user is ready for processing."""
-
-    def __init__(self, source):
-        super().__init__(source)
+    pass
 
 
 class RenderScreenSignal(AbstractSignal):

--- a/simpleline/render/adv_widgets.py
+++ b/simpleline/render/adv_widgets.py
@@ -42,7 +42,8 @@ class ErrorDialog(UIScreen):
     def refresh(self, args=None):
         super().refresh(args)
         text = widgets.TextWidget(self._message)
-        self.window += [widgets.CenterWidget(text), ""]
+        self.window.add(widgets.CenterWidget(text))
+        self.window.add_separator()
 
     def prompt(self, args=None):
         return Prompt(_("Press %s to exit") % Prompt.ENTER)
@@ -72,7 +73,8 @@ class PasswordDialog(UIScreen):
     def refresh(self, args=None):
         super().refresh(args)
         text = widgets.TextWidget(self._message)
-        self.window += [widgets.CenterWidget(text), ""]
+        self.window.add(widgets.CenterWidget(text))
+        self.window.add_separator()
 
     def prompt(self, args=None):
         self._password = App.get_scheduler().io_manager.get_user_input(_("Passphrase: "), hidden=True)
@@ -116,7 +118,8 @@ class YesNoDialog(UIScreen):
     def refresh(self, args=None):
         super().refresh(args)
         text = widgets.TextWidget(self._message)
-        self.window += [widgets.CenterWidget(text), ""]
+        self.window.add(widgets.CenterWidget(text))
+        self.window.add_separator()
 
     def prompt(self, args=None):
         return Prompt(_("Please respond '%(yes)s' or '%(no)s'") % {
@@ -170,7 +173,8 @@ class HelpScreen(UIScreen):
             with open(self.help_path, 'r') as f:
                 help_message = f.read()
 
-        self.window += [widgets.TextWidget(help_message), ""]
+        self.window.add(widgets.TextWidget(help_message))
+        self.window.add_separator()
 
     def input(self, args, key):
         """ Handle user input. """

--- a/simpleline/render/containers.py
+++ b/simpleline/render/containers.py
@@ -35,8 +35,9 @@ class Container(Widget):
         """
         super().__init__()
         self._items = []
-        for i in items:
-            self._items.append(ContainerItem(i))
+        if items:
+            for i in items:
+                self._items.append(ContainerItem(i))
 
     def add(self, item, callback=None, data=None):
         """Add item to the Container.

--- a/simpleline/render/containers.py
+++ b/simpleline/render/containers.py
@@ -1,0 +1,211 @@
+# Widgets for holding other widgets.
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from math import ceil
+
+from simpleline.render.widgets import Widget
+
+__all__ = ["ListRowContainer", "ListColumnContainer"]
+
+
+class Container(Widget):
+    """Base class for containers which will do positioning of the widgets."""
+
+    def __init__(self, items=None):
+        """Construct Container.
+
+        :param items: Array of items for positioning in this Container. Callback can't be specified this way.
+        :type items: List of items for rendering.
+        """
+        super().__init__()
+        self._items = []
+        for i in items:
+            self._items.append(ContainerItem(i))
+
+    def add(self, item, callback=None, data=None):
+        """Add item to the Container.
+
+        :param item: Add item to this container.
+        :type item: Could be item (based on `simpleline.render.widgets.Widget`)
+                    or other container (based on `simpleline.render.containers.Container`).
+
+        :param callback: Add callback for this item. This callback will be called when user activate this `item`.
+        :type callback: function ``func(item, data)``.
+
+        :param data: Data which will be passed to the callback.
+        :param data: Anything.
+
+        :returns: ID of the item in this Container.
+        :rtype: int
+        """
+        self._items.append(ContainerItem(item, callback, data))
+        return len(self._items) - 1
+
+
+class ListRowContainer(Container):
+    """Place widgets in rows automatically.
+
+    Compared to the ColumnWidget this is able to handle word wrapping correctly.
+
+    Widgets will be placed based on the number of columns in the following way:
+
+    w1   w2   w3
+    w4   w5   w6
+    ....
+    """
+
+    def __init__(self, columns, widgets=None, columns_width=25, spacing=3):
+        """Create ListWidget with specific number of columns.
+
+        :param columns: How many columns we want.
+        :type columns: int, bigger than 0
+
+        :param widgets: List of `WidgetContainer`s. This will be positioned in the ListWidget.
+        :type widgets: Array of `Widget` based class.
+
+        :param columns_width: Width of every column.
+        :type columns_width: int
+
+        :param spacing: Set the spacing between columns.
+        :type spacing: int
+        """
+        super().__init__(widgets)
+        self._columns = columns
+        self._columns_width = columns_width
+        self._spacing = spacing
+
+    def prepare_list(self):
+        """Prepare list for items ordering to rows and columns.
+
+        List will be prepared as ([column 1], [column 2], ...)
+        """
+        return list(map(lambda x: [], range(0, self._columns)))
+
+    def render(self, width):
+        """Render widgets to it's internal buffer.
+
+        :param width: the maximum width the item can use
+        :type width: int
+
+        :return: nothing
+        """
+        super().render(width)
+
+        ordered_items = self._order_items()
+        lines_per_rows = self.render_and_calculate_lines_per_rows(ordered_items)
+
+        # the leftmost empty column
+        col_pos = 0
+
+        for col in ordered_items:
+            row_pos = 0
+
+            # render and draw contents of column
+            for row_id, container in enumerate(col):
+                widget = container.widget
+                # set cursor to first line and leftmost empty column
+                self.set_cursor_position(row_pos, col_pos)
+
+                self.draw(widget, block=True)
+                row_pos = row_pos + lines_per_rows[row_id]
+
+            # recompute the leftmost empty column
+            col_pos = max((col_pos + self._columns_width), self.width) + self._spacing
+
+    def render_and_calculate_lines_per_rows(self, ordered_items):
+        """Render all items and then find how many lines are required for every row.
+
+        This will call `self._render_all_items()` and `self._lines_per_every_row()` in correct order.
+        """
+        self._render_all_items()
+        return self._lines_per_every_row(ordered_items)
+
+    def _render_all_items(self):
+        for item in self._items:
+            item.widget.render(self._columns_width)
+
+    def _lines_per_every_row(self, items):
+        # call `self._render_and_calculate_lines_per_rows()` method instead
+        lines_per_row = []
+
+        # go through all items and find how many lines we need for each row printed (because of wrapping)
+        for column_items in items:
+            for row_id, item in enumerate(column_items):
+                if len(lines_per_row) <= row_id:
+                    lines_per_row.append(0)
+
+                lines_per_row[row_id] = max(lines_per_row[row_id], len(item.widget.get_lines()))
+
+        return lines_per_row
+
+    def _order_items(self):
+        # create list of columns (lists)
+        positioned_items = self.prepare_list()
+
+        for item_id, item in enumerate(self._items):
+            positioned_items[item_id % self._columns].append(item)
+
+        return positioned_items
+
+
+class ListColumnContainer(ListRowContainer):
+    """Place widgets in columns automatically.
+
+    Compared to the ColumnWidget this is able to handle word wrapping correctly.
+
+    Widgets will be placed based on the number of columns in the following way:
+
+    w1   w4   w7
+    w2   w5   w8
+    w3   w6   w9
+    """
+
+    def _order_items(self):
+        positioned_items = self.prepare_list()
+        items_in_column = ceil(len(self._items) / self._columns)
+
+        for item_id, item in enumerate(self._items):
+            col_position = int(item_id // items_in_column)
+            positioned_items[col_position].append(item)
+
+        return positioned_items
+
+
+class ContainerItem(object):
+    """Item used inside of containers to store widgets callbacks and data.
+
+    Internal representation for Containers. Do not use this class directly.
+    """
+
+    def __init__(self, widget, callback=None, data=None):
+        """Construct WidgetContainer.
+
+        :param widget: Any item from `simpleline.render.widgets` or `Container`.
+        :type widget: Class subclassing the `simpleline.render.widgets.Widget` class
+                    or `simpleline.render.containers.Container`.
+
+        :param callback: This callback will be called as reaction on user input.
+        :type callback: Function with one data parameter: `def func(data):`.
+
+        :param data: Params which will be passed to callback.
+        :type data: Anything.
+        """
+        self.widget = widget
+        self.callback = callback
+        self.data = data

--- a/simpleline/render/io_manager.py
+++ b/simpleline/render/io_manager.py
@@ -123,7 +123,7 @@ class InOutManager(object):
 
         # None means prompt handled the input by itself -> continue
         if prompt is None:
-            return True
+            return UserInputResult.PROCESSED
 
         # get the input from user
         c = self.get_user_input(prompt)

--- a/simpleline/render/widgets.py
+++ b/simpleline/render/widgets.py
@@ -25,8 +25,7 @@ from textwrap import wrap
 from simpleline.utils.i18n import _
 from simpleline.utils import ensure_str
 
-__all__ = ["Widget", "TextWidget", "ColumnWidget", "CheckboxWidget",
-           "CenterWidget"]
+__all__ = ["Widget", "TextWidget", "SeparatorWidget", "ColumnWidget", "CheckboxWidget", "CenterWidget"]
 
 
 class Widget(object):
@@ -100,7 +99,7 @@ class Widget(object):
     def cursor(self):
         return self._cursor
 
-    def setend(self):
+    def set_end(self):
         """Set the cursor to first column in new line at the end."""
         self._cursor = (self.height, 0)
 
@@ -261,11 +260,41 @@ class TextWidget(Widget):
 
         :param width: maximum width allocated to the string
         :type width: int
-
-        :raises
         """
         super().render(width)
         self.write(self._text, width=width, wordwrap=True)
+
+
+class SeparatorWidget(Widget):
+    """Print empty line."""
+
+    def __init__(self, lines=1):
+        """Construct SeparatorWidget for printing blank lines.
+
+        :param lines: How many lines should be blank.
+        :type lines: int greater than 0.
+        """
+        super().__init__()
+        self._lines = lines
+
+    def render(self, width):
+        """Render empty line to the buffer.
+
+        :param width: maximum width allocated to the string
+        :type width: int
+        """
+        super().render(width)
+        self.write("")
+
+    def write(self, text, row=None, col=None, width=None, block=False, wordwrap=False):
+        """Optimize write function.
+
+        To print just a blank line we don't need too much logic.
+        """
+        for i in range(0, self._lines):
+            self._buffer.append(list())
+            self._buffer[i] += u""
+        self.set_cursor_position(self._lines - 1, 0)
 
 
 class CenterWidget(Widget):

--- a/simpleline/render/widgets.py
+++ b/simpleline/render/widgets.py
@@ -251,6 +251,11 @@ class TextWidget(Widget):
         super().__init__()
         self._text = text
 
+    @property
+    def text(self):
+        """Contains text of this widget."""
+        return self._text
+
     def render(self, width):
         """Renders the text widget limited to width number of columns (wraps to the next line when the text is longer).
 

--- a/tests/event_queue_test.py
+++ b/tests/event_queue_test.py
@@ -98,5 +98,5 @@ class EventQueue_TestCase(unittest.TestCase):
 
 class TestSignal(AbstractSignal):
 
-    def __init__(self, source=None, priority=20):
+    def __init__(self, source=None, priority=20):  # pylint: disable=useless-super-delegation
         super().__init__(source, priority)

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -253,9 +253,6 @@ class EmptyScreen(UIScreen):
         EmptyScreen.title = ""
         self.input_required = False
 
-    def refresh(self, args=None):
-        super().refresh(args)
-
     def show_all(self):
         self.close()
 
@@ -272,9 +269,6 @@ class TestScreenSetupFail(UIScreen):
     def setup(self, args):
         super().setup(args)
         return False
-
-    def refresh(self, args=None):
-        super().refresh(args)
 
 
 class InputErrorTestScreen(UIScreen):
@@ -329,9 +323,6 @@ class NoInputScreen(UIScreen):
     def __init__(self):
         super().__init__()
         self.input_required = False
-
-    def refresh(self, args=None):
-        super().refresh(args)
 
     def show_all(self):
         super().show_all()

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -168,6 +168,11 @@ class ScreenException_TestCase(unittest.TestCase):
 @mock.patch('simpleline.render.io_manager.InOutManager._get_input')
 class InputProcessing_TestCase(unittest.TestCase):
 
+    def _test_getpass(self, prompt):
+        self.pass_prompt = prompt
+        self.pass_called = True
+        return "test"
+
     def setUp(self):
         self.pass_called = False
         self.pass_prompt = None
@@ -227,6 +232,15 @@ class InputProcessing_TestCase(unittest.TestCase):
         self.assertEqual(screen.render_counter, 3)
         self.assertEqual(screen.error_counter, threshold)
 
+    def test_input_no_prompt(self, mock_stdin, mock_stdout):
+        screen = InputWithNoPrompt()
+
+        App.initialize()
+        App.get_scheduler().schedule_screen(screen)
+        App.run()
+
+        self.assertTrue(screen.prompt_entered)
+
     @mock.patch('simpleline.event_loop.main_loop.MainLoop.process_signals')
     def test_custom_getpass(self, mock_stdin, mock_stdout, process_signals):
         prompt = mock.MagicMock()
@@ -236,11 +250,6 @@ class InputProcessing_TestCase(unittest.TestCase):
 
         self.assertTrue(self.pass_called)
         self.assertEqual(self.pass_prompt, prompt)
-
-    def _test_getpass(self, prompt):
-        self.pass_prompt = prompt
-        self.pass_called = True
-        return "test"
 
 
 # HELPER CLASSES
@@ -291,6 +300,20 @@ class InputErrorTestScreen(UIScreen):
 
     def show_all(self):
         self.render_counter += 1
+
+
+class InputWithNoPrompt(UIScreen):
+
+    def __init__(self):
+        super().__init__()
+        self.prompt_entered = False
+        self.input_required = True
+
+    def prompt(self, args=None):
+        self.prompt_entered = True
+        self.close()
+        # do not process input - it was processed here by user
+        return None
 
 
 class RefreshTestScreen(UIScreen):

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -111,9 +111,6 @@ class ShowedCounterScreen(UIScreen):
         self.counter = 0
         self.input_required = False
 
-    def refresh(self, args=None):
-        super().refresh(args)
-
     def show_all(self):
         super().show_all()
         self.counter += 1
@@ -192,6 +189,3 @@ class InputAndDrawScreen(UIScreen):
     def __init__(self, msg):
         super().__init__()
         self.title = msg
-
-    def refresh(self, args=None):
-        super().refresh(args)

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -23,6 +23,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from simpleline.base import App
+from simpleline.render import InputState
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
 
@@ -185,7 +186,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         pass
 
     def test_listrow_container(self):
-        c = ListRowContainer(columns=2, widgets=[self.w2, self.w3, self.w5], columns_width=10, spacing=2)
+        c = ListRowContainer(columns=2, items=[self.w2, self.w3, self.w5], columns_width=10, spacing=2, numbering=False)
         c.render(25)
 
         expected_result = [u"Test        Test 2",
@@ -203,7 +204,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         self.assertEqual(len(result), 0)
 
     def test_more_columns_than_widgets(self):
-        c = ListRowContainer(columns=3, widgets=[self.w1], columns_width=40)
+        c = ListRowContainer(columns=3, items=[self.w1], columns_width=40, numbering=False)
         c.render(80)
 
         expected_result = [u"Můj krásný dlouhý text"]
@@ -213,7 +214,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
 
     def test_listrow_wrapping(self):
         # spacing is 3 by default
-        c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15)
+        c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15, numbering=False)
         c.render(25)
 
         expected_result = [u"Můj krásný        Test",
@@ -227,7 +228,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         widgets = [TextWidget("Hello"), TextWidget("Wrap\nthis\ntext"), TextWidget("Hi"),
                    TextWidget("Hello2")]
 
-        c = ListRowContainer(3, widgets, columns_width=6, spacing=1)
+        c = ListRowContainer(3, widgets, columns_width=6, spacing=1, numbering=False)
         c.render(80)
 
         expected_result = [u"Hello  Wrap   Hi",
@@ -238,7 +239,8 @@ class Containers_TestCase(BaseWidgets_TestCase):
         self.evaluate_result(res_lines, expected_result)
 
     def test_listcolumn_widget(self):
-        c = ListColumnContainer(columns=2, widgets=[self.w2, self.w3, self.w5], columns_width=10, spacing=2)
+        c = ListColumnContainer(columns=2, items=[self.w2, self.w3, self.w5], columns_width=10, spacing=2,
+                                numbering=False)
         c.render(25)
 
         expected_result = [u"Test        Test 3",
@@ -248,7 +250,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
 
     def test_listcolumn_widget_wrapping(self):
         # spacing is 3 by default
-        c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15)
+        c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15, numbering=False)
         c.render(25)
 
         expected_result = [u"Můj krásný        Test 2",
@@ -259,7 +261,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         self.evaluate_result(res_lines, expected_result)
 
     def test_add_new_container(self):
-        c = ListRowContainer(columns=2, widgets=[TextWidget("Ahoj")], columns_width=15, spacing=0)
+        c = ListRowContainer(columns=2, items=[TextWidget("Ahoj")], columns_width=15, spacing=0, numbering=False)
 
         expected_result = [u"Ahoj"]
 
@@ -278,12 +280,11 @@ class Containers_TestCase(BaseWidgets_TestCase):
     def test_column_numbering(self):
         # spacing is 3 by default
         c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=16)
-        c.key_pattern = KeyPattern()
         c.render(25)
 
-        expected_result = [u"1. Můj krásný      3. Test 2",
+        expected_result = [u"1) Můj krásný      3) Test 2",
                            u"   dlouhý text",
-                           u"2. Test            4. Krásný dlouhý",
+                           u"2) Test            4) Krásný dlouhý",
                            u"                      text podruhé"]
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
@@ -291,12 +292,11 @@ class Containers_TestCase(BaseWidgets_TestCase):
     def test_row_numbering(self):
         # spacing is 3 by default
         c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=16)
-        c.key_pattern = KeyPattern()
         c.render(25)
 
-        expected_result = [u"1. Můj krásný      2. Test",
+        expected_result = [u"1) Můj krásný      2) Test",
                            u"   dlouhý text",
-                           u"3. Test 2          4. Krásný dlouhý",
+                           u"3) Test 2          4) Krásný dlouhý",
                            u"                      text podruhé"]
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
@@ -313,7 +313,6 @@ class Containers_TestCase(BaseWidgets_TestCase):
                            u"                             text podruhé"]
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
-        self.assertEqual(c.key_pattern.get_widget_identifier(1), "2")
 
 
 @patch('simpleline.render.io_manager.InOutManager._get_input')
@@ -365,6 +364,18 @@ class WidgetProcessing_TestCase(unittest.TestCase):
 
         self.assertEqual(self._expected_output(widget_text, 4), out_mock.getvalue())
 
+    def test_list_widget_input_processing(self, out_mock, in_mock):
+        # call first container callback
+        in_mock.return_value = "2"
+
+        screen = ScreenWithListWidget(3)
+
+        App.initialize()
+        App.get_scheduler().schedule_screen(screen)
+        App.run()
+
+        self.assertEqual(1, screen.container_callback_input)
+
 
 class ScreenWithWidget(UIScreen):
 
@@ -380,3 +391,31 @@ class ScreenWithWidget(UIScreen):
     def show_all(self):
         super().show_all()
         self.close()
+
+
+class ScreenWithListWidget(UIScreen):
+
+    def __init__(self, widgets_count):
+        super().__init__()
+        self._widgets_count = widgets_count
+        self._list_widget = None
+        self.container_callback_input = -1
+
+    def refresh(self, args=None):
+        super().refresh(args)
+
+        self._list_widget = ListRowContainer(2)
+        for i in range(self._widgets_count):
+            self._list_widget.add(TextWidget("Test %s" % i), self._callback, i)
+
+        self.window = [self._list_widget]
+
+    def input(self, args, key):
+        self.close()
+        if self._list_widget.process_user_input(key):
+            return InputState.PROCESSED
+
+        return InputState.DISCARDED
+
+    def _callback(self, data):
+        self.container_callback_input = data

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -24,11 +24,10 @@ from unittest.mock import patch
 
 from simpleline.base import App
 from simpleline.render import InputState
+from simpleline.render.containers import WindowContainer, ListRowContainer, ListColumnContainer, KeyPattern
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
-
 from simpleline.render.widgets import TextWidget, SeparatorWidget, CheckboxWidget, CenterWidget, ColumnWidget
-from simpleline.render.containers import ListRowContainer, ListColumnContainer, KeyPattern
 
 
 class BaseWidgets_TestCase(unittest.TestCase):
@@ -59,6 +58,28 @@ class BaseWidgets_TestCase(unittest.TestCase):
 
 
 class Widgets_TestCase(BaseWidgets_TestCase):
+
+    def test_separator_widget(self):
+        w = SeparatorWidget()
+        w.render(80)
+
+        res_lines = w.get_lines()
+
+        expected_result = [u""]
+
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_separator_widget_multiline(self):
+        w = SeparatorWidget(3)
+        w.render(80)
+
+        res_lines = w.get_lines()
+
+        expected_result = [u"",
+                           u"",
+                           u""]
+
+        self.evaluate_result(res_lines, expected_result)
 
     def test_column_widget(self):
         # Test column text
@@ -238,7 +259,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
 
-    def test_listcolumn_widget(self):
+    def test_listcolumn_container(self):
         c = ListColumnContainer(columns=2, items=[self.w2, self.w3, self.w5], columns_width=10, spacing=2,
                                 numbering=False)
         c.render(25)
@@ -248,7 +269,7 @@ class Containers_TestCase(BaseWidgets_TestCase):
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
 
-    def test_listcolumn_widget_wrapping(self):
+    def test_listcolumn_wrapping(self):
         # spacing is 3 by default
         c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15, numbering=False)
         c.render(25)
@@ -311,6 +332,51 @@ class Containers_TestCase(BaseWidgets_TestCase):
                            u"      dlouhý text",
                            u"a 3 a Test 2           a 4 a Krásný dlouhý",
                            u"                             text podruhé"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_window_container(self):
+        c = WindowContainer(title="Test")
+
+        c.add(TextWidget("Body"))
+        c.render(10)
+
+        expected_result = [u"Test",
+                           u"",
+                           u"Body"]
+
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_window_container_with_multiple_items(self):
+        c = WindowContainer(title="Test")
+
+        c.add(TextWidget("Body"))
+        c.add(TextWidget("Body second line"))
+        c.render(30)
+
+        expected_result = [u"Test",
+                           u"",
+                           u"Body",
+                           u"Body second line"]
+
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_window_container_wrapping(self):
+        c = WindowContainer(title="Test")
+
+        c.add(TextWidget("Body long line"))
+        c.add(TextWidget("Body"))
+        c.render(5)
+
+        expected_result = [u"Test",
+                           u"",
+                           u"Body",
+                           u"long",
+                           u"line",
+                           u"Body"]
+
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
 
@@ -386,7 +452,7 @@ class ScreenWithWidget(UIScreen):
 
     def refresh(self, args=None):
         super().refresh(args)
-        self.window = [TextWidget(self._msg)]
+        self.window.add(TextWidget(self._msg))
 
     def show_all(self):
         super().show_all()
@@ -408,7 +474,7 @@ class ScreenWithListWidget(UIScreen):
         for i in range(self._widgets_count):
             self._list_widget.add(TextWidget("Test %s" % i), self._callback, i)
 
-        self.window = [self._list_widget]
+        self.window.add(self._list_widget)
 
     def input(self, args, key):
         self.close()

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -27,7 +27,7 @@ from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
 
 from simpleline.render.widgets import TextWidget, CheckboxWidget, CenterWidget, ColumnWidget
-from simpleline.render.containers import ListRowContainer, ListColumnContainer
+from simpleline.render.containers import ListRowContainer, ListColumnContainer, KeyPattern
 
 
 class BaseWidgets_TestCase(unittest.TestCase):
@@ -274,6 +274,46 @@ class Containers_TestCase(BaseWidgets_TestCase):
 
         c.render(80)
         self.evaluate_result(c.get_lines(), expected_result)
+
+    def test_column_numbering(self):
+        # spacing is 3 by default
+        c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=16)
+        c.key_pattern = KeyPattern()
+        c.render(25)
+
+        expected_result = [u"1. Můj krásný      3. Test 2",
+                           u"   dlouhý text",
+                           u"2. Test            4. Krásný dlouhý",
+                           u"                      text podruhé"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_row_numbering(self):
+        # spacing is 3 by default
+        c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=16)
+        c.key_pattern = KeyPattern()
+        c.render(25)
+
+        expected_result = [u"1. Můj krásný      2. Test",
+                           u"   dlouhý text",
+                           u"3. Test 2          4. Krásný dlouhý",
+                           u"                      text podruhé"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_custom_numbering(self):
+        # spacing is 3 by default
+        c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=20)
+        c.key_pattern = KeyPattern("a {:d} a ")
+        c.render(25)
+
+        expected_result = [u"a 1 a Můj krásný       a 2 a Test",
+                           u"      dlouhý text",
+                           u"a 3 a Test 2           a 4 a Krásný dlouhý",
+                           u"                             text podruhé"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+        self.assertEqual(c.key_pattern.get_widget_identifier(1), "2")
 
 
 @patch('simpleline.render.io_manager.InOutManager._get_input')

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -26,6 +26,7 @@ from simpleline.base import App
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
 from simpleline.render.widgets import TextWidget, ColumnWidget
+from simpleline.render.containers import ListRowContainer, ListColumnContainer
 
 
 class Widgets_TestCase(unittest.TestCase):
@@ -78,6 +79,49 @@ class Widgets_TestCase(unittest.TestCase):
                            u"Test 2          podruhé",
                            u"                Test 3"]
 
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_listrow_widget(self):
+        c = ListRowContainer(columns=2, widgets=[self.w2, self.w3, self.w5], columns_width=10, spacing=2)
+        c.render(25)
+
+        expected_result = [u"Test        Test 2",
+                           u"Test 3"]
+        res_lines = c.get_lines()
+
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_listrow_widget_wrapping(self):
+        # spacing is 3 by default
+        c = ListRowContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15)
+        c.render(25)
+
+        expected_result = [u"Můj krásný        Test",
+                           u"dlouhý text",
+                           u"Test 2            Krásný dlouhý",
+                           u"                  text podruhé"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_listcolumn_widget(self):
+        c = ListColumnContainer(columns=2, widgets=[self.w2, self.w3, self.w5], columns_width=10, spacing=2)
+        c.render(25)
+
+        expected_result = [u"Test        Test 3",
+                           u"Test 2"]
+        res_lines = c.get_lines()
+        self.evaluate_result(res_lines, expected_result)
+
+    def test_listcolumn_widget_wrapping(self):
+        # spacing is 3 by default
+        c = ListColumnContainer(2, [self.w1, self.w2, self.w3, self.w4], columns_width=15)
+        c.render(25)
+
+        expected_result = [u"Můj krásný        Test 2",
+                           u"dlouhý text",
+                           u"Test              Krásný dlouhý",
+                           u"                  text podruhé"]
         res_lines = c.get_lines()
         self.evaluate_result(res_lines, expected_result)
 

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -27,7 +27,7 @@ from simpleline.render import InputState
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
 
-from simpleline.render.widgets import TextWidget, CheckboxWidget, CenterWidget, ColumnWidget
+from simpleline.render.widgets import TextWidget, SeparatorWidget, CheckboxWidget, CenterWidget, ColumnWidget
 from simpleline.render.containers import ListRowContainer, ListColumnContainer, KeyPattern
 
 


### PR DESCRIPTION
These containers are automatically printing widgets with a correct ordering and line wrapping.

Containers are able to automatically add labels (keys) for every item and react on user input on these labels by calling callbacks registered for these items.

These widgets should replace `ColumnWidget`, however, `ColumnWidget` can still be used for some specific use-cases.