### PR TITLE
Fix potfile generation

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -24,7 +24,7 @@ MSGFMT		= msgfmt --statistics --verbose
 # What do we need to do
 POFILES		= $(wildcard *.po)
 MOFILES		= $(patsubst %.po,%.mo,$(POFILES))
-PYSRC		= $(wildcard ../simpleline/*.py)
+PYSRC		= $(wildcard ../simpleline/*.py) $(wildcard ../simpleline/**/*.py)
 
 all::  update-po $(MOFILES)
 


### PR DESCRIPTION
More than one level of directories are now present in `simpleline`.
We need to find sources for `potfile` generation recursively now.