### PR TITLE
Fix `ready` property collision with Anaconda

### DIFF
--- a/examples/entry_counter/entry_counter.py
+++ b/examples/entry_counter/entry_counter.py
@@ -42,7 +42,7 @@ class CounterScreen(UIScreen):
         self._counter = 0
 
     def closed(self):
-        self.ready = False
+        self.screen_ready = False
 
     def setup(self, args=None):
         super().setup(args)

--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -45,7 +45,7 @@ class UIScreen(SignalHandler, SchedulerHandler):
         """
         self._title = title
         self._screen_height = screen_height
-        self._ready = False
+        self._screen_ready = False
 
         # list that holds the content to be printed out
         self._window = WindowContainer(self.title)
@@ -71,14 +71,14 @@ class UIScreen(SignalHandler, SchedulerHandler):
         self._title = title
 
     @property
-    def ready(self):
+    def screen_ready(self):
         """This screen is ready for use."""
-        return self._ready
+        return self._screen_ready
 
-    @ready.setter
-    def ready(self, ready):
+    @screen_ready.setter
+    def screen_ready(self, screen_ready):
         """Set ready status for this screen."""
-        self._ready = ready
+        self._screen_ready = screen_ready
 
     @property
     def input_required(self):
@@ -125,7 +125,7 @@ class UIScreen(SignalHandler, SchedulerHandler):
         :return: whether this screen should be scheduled or not
         :rtype: bool
         """
-        self._ready = True
+        self._screen_ready = True
         App.get_event_loop().register_signal_source(self)
         return True
 

--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -189,7 +189,7 @@ class ScreenScheduler(object):
         top_screen = self._get_last_screen()
 
         # this screen is used first time (call setup() method)
-        if not top_screen.ui_screen.ready:
+        if not top_screen.ui_screen.screen_ready:
             if not top_screen.ui_screen.setup(top_screen.args):
                 # remove the screen and skip if setup went wrong
                 self._screen_stack.pop()

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -195,8 +195,8 @@ class InputProcessing_TestCase(unittest.TestCase):
         App.get_scheduler().schedule_screen(screen2)
         App.run()
 
-        self.assertTrue(screen.ready)
-        self.assertTrue(screen.ready)
+        self.assertTrue(screen.screen_ready)
+        self.assertTrue(screen.screen_ready)
 
     def test_refresh_input(self, mock_stdin, mock_stdout):
         mock_stdin.return_value = "r"


### PR DESCRIPTION
Anaconda is using `ready` property for spokes in GUI and TUI. To fix this collision the `ready` property in simpleline is renamed to `screen_ready`.