### PR TITLE
Move InputState next to UIScreen

### DIFF
--- a/examples/entry_counter/entry_counter.py
+++ b/examples/entry_counter/entry_counter.py
@@ -1,8 +1,7 @@
 #!/bin/python3
 
 from simpleline import App
-from simpleline.render import InputState
-from simpleline.render.screen import UIScreen
+from simpleline.render.screen import UIScreen, InputState
 from simpleline.render.widgets import TextWidget, CenterWidget
 
 

--- a/examples/hub_spoke/hub_spoke.py
+++ b/examples/hub_spoke/hub_spoke.py
@@ -3,8 +3,7 @@
 from simpleline import App
 from simpleline.render.adv_widgets import PasswordDialog
 from simpleline.render.prompt import Prompt
-from simpleline.render.screen import UIScreen
-from simpleline.render import InputState
+from simpleline.render.screen import UIScreen, InputState
 from simpleline.render.widgets import TextWidget, ColumnWidget, CenterWidget
 
 

--- a/examples/ignore_continue/ignore_continue.py
+++ b/examples/ignore_continue/ignore_continue.py
@@ -1,9 +1,8 @@
 #!/bin/python3
 
 from simpleline import App
-from simpleline.render import InputState
 from simpleline.render.prompt import Prompt
-from simpleline.render.screen import UIScreen
+from simpleline.render.screen import UIScreen, InputState
 from simpleline.render.widgets import TextWidget, CenterWidget
 
 

--- a/simpleline/__init__.py
+++ b/simpleline/__init__.py
@@ -19,9 +19,6 @@
 # Red Hat, Inc.
 #
 
-from simpleline.event_loop.main_loop import MainLoop
-from simpleline.render.screen_scheduler import ScreenScheduler
-
 __all__ = ["App"]
 
 
@@ -59,6 +56,9 @@ class App(object):
                            if not specified use `simpleline.event_loop.main_loop.MainLoop`.
         :type event_loop: object based on class `simpleline.event_loop.AbstractEventLoop`.
         """
+        from simpleline.event_loop.main_loop import MainLoop
+        from simpleline.render.screen_scheduler import ScreenScheduler
+
         if event_loop is None:
             event_loop = MainLoop()
         if scheduler is None:

--- a/simpleline/render/__init__.py
+++ b/simpleline/render/__init__.py
@@ -19,7 +19,6 @@
 # Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 
-from enum import Enum
 from simpleline.errors import SimplelineError
 
 
@@ -29,8 +28,3 @@ class RenderError(SimplelineError):
 
 class RenderUnexpectedError(RenderError):
     pass
-
-
-class InputState(Enum):
-    PROCESSED = True
-    DISCARDED = False

--- a/simpleline/render/adv_widgets.py
+++ b/simpleline/render/adv_widgets.py
@@ -20,9 +20,9 @@
 import sys
 
 from simpleline import App
-from simpleline.render import widgets, InputState
+from simpleline.render import widgets
 from simpleline.render.prompt import Prompt
-from simpleline.render.screen import UIScreen
+from simpleline.render.screen import UIScreen, InputState
 from simpleline.utils.i18n import _, N_, C_
 
 

--- a/simpleline/render/io_manager.py
+++ b/simpleline/render/io_manager.py
@@ -27,7 +27,7 @@ import getpass
 
 from enum import Enum
 
-from simpleline.render import InputState
+from simpleline.render.screen import InputState
 from simpleline.event_loop import ExitMainLoop
 from simpleline.event_loop.signals import ExceptionSignal, InputReadySignal
 from simpleline.render.prompt import Prompt

--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -19,6 +19,8 @@
 # Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 
+from enum import Enum
+
 from simpleline import App
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen.signal_handler import SignalHandler
@@ -210,3 +212,8 @@ class UIScreen(SignalHandler, SchedulerHandler):
     def closed(self):
         """Callback when this screen is closed."""
         pass
+
+
+class InputState(Enum):
+    PROCESSED = True
+    DISCARDED = False

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -23,8 +23,8 @@ from io import StringIO
 from unittest import mock
 
 from simpleline import App
-from simpleline.render import InputState, RenderUnexpectedError
-from simpleline.render.screen import UIScreen
+from simpleline.render import RenderUnexpectedError
+from simpleline.render.screen import UIScreen, InputState
 from tests import schedule_screen_and_run, calculate_separator
 
 

--- a/tests/widgets_test.py
+++ b/tests/widgets_test.py
@@ -23,10 +23,9 @@ from io import StringIO
 from unittest.mock import patch
 
 from simpleline import App
-from simpleline.render import InputState
 from simpleline.render.containers import WindowContainer, ListRowContainer, ListColumnContainer, KeyPattern
 from simpleline.render.prompt import Prompt
-from simpleline.render.screen import UIScreen
+from simpleline.render.screen import UIScreen, InputState
 from simpleline.render.widgets import TextWidget, SeparatorWidget, CheckboxWidget, CenterWidget, ColumnWidget
 
 


### PR DESCRIPTION
From the user perspective the `UIScreen` is the only class using this `enum`.