### PR TITLE
Keep backward compatibility for UIScreen args

### DIFF
--- a/simpleline/render/screen_stack.py
+++ b/simpleline/render/screen_stack.py
@@ -90,10 +90,7 @@ class ScreenData(object):
 
     def __init__(self, ui_screen, args=None, execute_new_loop=False):
         self.ui_screen = ui_screen
-        if args is None:
-            self.args = []
-        else:
-            self.args = args
+        self.args = args
         self.execute_new_loop = execute_new_loop
 
     def __str__(self):

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -77,7 +77,7 @@ class Scheduler_TestCase(unittest.TestCase):
         self.scheduler.schedule_screen(screen)
         test_screen = self.pop_last_item(False)
         self.assertEqual(test_screen.ui_screen, screen)
-        self.assertEqual(len(test_screen.args), 0)  # empty field - no arguments
+        self.assertEqual(test_screen.args, None)  # empty field - no arguments
         self.assertFalse(test_screen.execute_new_loop)
 
         # Schedule another screen, new one will be added to the bottom of the stack
@@ -140,7 +140,7 @@ class Scheduler_TestCase(unittest.TestCase):
 
         test_screen = self.pop_last_item()
         self.assertEqual(test_screen.ui_screen, new_screen)
-        self.assertEqual(test_screen.args, [])
+        self.assertEqual(test_screen.args, None)
         self.assertEqual(test_screen.execute_new_loop, False)
 
         # We popped the new_screen so the old screen should stay here
@@ -174,7 +174,7 @@ class Scheduler_TestCase(unittest.TestCase):
 
         test_screen = self.pop_last_item()
         self.assertEqual(test_screen.ui_screen, new_screen)
-        self.assertEqual(test_screen.args, [])
+        self.assertEqual(test_screen.args, None)
         self.assertEqual(test_screen.execute_new_loop, True)
 
     @mock.patch('simpleline.render.io_manager.InOutManager.draw')

--- a/tests/screen_stack_test.py
+++ b/tests/screen_stack_test.py
@@ -118,7 +118,7 @@ class ScreenData_TestCase(unittest.TestCase):
     def test_screen_data(self):
         self._prepare()
         screen = ScreenData(self.ui_screen)
-        self._screen_check(screen, self.ui_screen, [], False)
+        self._screen_check(screen, self.ui_screen, None, False)
 
     def test_screen_data_with_args(self):
         self._prepare()
@@ -132,10 +132,10 @@ class ScreenData_TestCase(unittest.TestCase):
     def test_screen_data_with_execute_loop(self):
         self._prepare()
         screen = ScreenData(self.ui_screen, execute_new_loop=True)
-        self._screen_check(screen, self.ui_screen, [], True)
+        self._screen_check(screen, self.ui_screen, None, True)
 
         screen2 = ScreenData(self.ui_screen, execute_new_loop=False)
-        self._screen_check(screen2, self.ui_screen, [], False)
+        self._screen_check(screen2, self.ui_screen, None, False)
 
     def test_screen_data_with_args_and_execute_loop(self):
         self._prepare()


### PR DESCRIPTION
Save `None` instead of `[]` to `UIScreen` `args` parameter. This parameter is used in methods like `refresh()`.

It is also expected behavior when everywhere is default `None`.