### PR TITLE
The ExitMainLoop exception should kill whole app

### DIFF
--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -83,7 +83,13 @@ class MainLoop(AbstractEventLoop):
         """
         log.debug("Starting main loop")
         self._run_loop = True
-        self._mainloop()
+
+        try:
+            self._mainloop()
+        except ExitMainLoop:
+            pass
+
+        log.debug("Main loop ended. Running callback if set.")
 
         if self._quit_callback:
             self._quit_callback()
@@ -106,7 +112,7 @@ class MainLoop(AbstractEventLoop):
 
         self.enqueue_signal(signal)
         self._mainloop()
-        log.debug("Inner loop ended")
+        log.debug("Inner loop is closed")
 
     def close_loop(self):
         """Close active event loop.
@@ -152,13 +158,9 @@ class MainLoop(AbstractEventLoop):
     def _mainloop(self):
         """Single mainloop. Do not use directly, start the application using run()."""
         # run infinite loop
-        # this will always wait on input processing or similar so it is not busy waiting
+        # this will always wait on input processing or similar so it should not busy waiting
         while self._run_loop:
-            try:
-                self.process_signals()
-            # end just this loop
-            except ExitMainLoop:
-                break
+            self.process_signals()
 
         # set back to True to leave outer loop working
         self._run_loop = True

--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -181,7 +181,7 @@ class MainLoop(AbstractEventLoop):
         # get unique ID when waiting for the signal
         unique_id = self._register_wait_on_signal(return_after)
 
-        while not self._active_queue.empty() or return_after is not None:
+        while self._can_process_signals() or return_after is not None:
             signal = self._active_queue.get()
             # all who is waiting on this signal can stop waiting
             self._mark_signal_processed(signal)
@@ -192,6 +192,10 @@ class MainLoop(AbstractEventLoop):
             # was our signal processed if yes, return this method
             if self._check_if_signal_processed(return_after, unique_id):
                 return
+
+    def _can_process_signals(self):
+        """To proceed signal processing, these conditions must be true."""
+        return not self._active_queue.empty() and self._run_loop
 
     def _process_signal(self, signal):
         log.debug("Processing signal %s", signal)

--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -188,7 +188,9 @@ class ScreenScheduler(object):
         # and if it is not modal screen (modal screen parent is blocked)
         if not self._screen_stack.empty() and not screen.execute_new_loop:
             self.redraw()
-        else:
+
+        # we can't draw anything more. Kill the application.
+        if self._screen_stack.empty():
             raise ExitMainLoop()
 
     def redraw(self):

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -56,8 +56,6 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_RENDER)
 
     def test_switch_screen_modal_in_refresh(self, _):
-        import logging
-        logging.basicConfig(filename="log.txt", level=logging.DEBUG)
         modal_screen = ModalTestScreen()
         screen = ModalTestScreen(modal_screen_refresh=modal_screen)
 


### PR DESCRIPTION
The `ExitMainLoop` exception should kill whole application not just inner loop.