### PR TITLE
Remove leftover print in containers parsing input

### DIFF
--- a/simpleline/render/containers.py
+++ b/simpleline/render/containers.py
@@ -21,7 +21,11 @@ from math import ceil
 
 from simpleline.render.widgets import Widget, TextWidget, SeparatorWidget
 
+from simpleline.logging import get_simpleline_logger
+
 __all__ = ["ListRowContainer", "ListColumnContainer", "WindowContainer"]
+
+log = get_simpleline_logger()
 
 
 class Container(Widget):
@@ -414,7 +418,7 @@ class KeyPattern(object):
         try:
             return int(user_input) - 1
         except ValueError:
-            print("Value Error")
+            log.debug("No callback registered for user input %s", user_input)
             return None
 
 


### PR DESCRIPTION
The *Value Error* was printed to the console. Now it is a debug log output with more information.