### PR TITLE
Rename quit callback and add args there.

### DIFF
--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -22,7 +22,11 @@
 #
 
 from abc import ABCMeta, abstractmethod
+from collections import namedtuple
+
 from simpleline.errors import SimplelineError
+
+QuitCallback = namedtuple("QuitCallback", ["callback", "args"])
 
 
 class ExitMainLoop(SimplelineError):
@@ -116,9 +120,16 @@ class AbstractEventLoop(metaclass=ABCMeta):
         """
         pass
 
-    def event_loop_quit_callback(self, callback):
-        """Call this callback when event loop quits."""
-        self._quit_callback = callback
+    def set_quit_callback(self, callback, args=None):
+        """Call this callback when event loop quits.
+
+        :param callback: Call this callback when event loops ends (application quit).
+        :type callback: Function with one parameter data `func(data)`.
+
+        :param args: Arguments passed to the quit callback.
+        :type args: Anything.
+        """
+        self._quit_callback = QuitCallback(callback, args)
 
 
 class AbstractSignal(metaclass=ABCMeta):

--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -92,7 +92,8 @@ class MainLoop(AbstractEventLoop):
         log.debug("Main loop ended. Running callback if set.")
 
         if self._quit_callback:
-            self._quit_callback()
+            cb = self._quit_callback.callback
+            cb(self._quit_callback.args)
 
     def execute_new_loop(self, signal):
         """Starts the new event loop and pass `signal` in it.


### PR DESCRIPTION
Quit callback in event loop now have an `args` argument which is passed to the callback.

Also rename it to `set_quit_callback()`.

Add test for the callback.