### PR TITLE
Screen scheduling is moved to ScreenHandler

### DIFF
--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -22,14 +22,13 @@
 from enum import Enum
 
 from simpleline import App
+from simpleline.render.containers import WindowContainer
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen.signal_handler import SignalHandler
-from simpleline.render.screen.scheduler_handler import SchedulerHandler
-from simpleline.render.containers import WindowContainer
 from simpleline.utils.i18n import _
 
 
-class UIScreen(SignalHandler, SchedulerHandler):
+class UIScreen(SignalHandler):
     """Base class representing one TUI Screen.
 
     Shares some API with anaconda's GUI to make it easy for devs to create similar UI

--- a/simpleline/render/screen_handler.py
+++ b/simpleline/render/screen_handler.py
@@ -1,4 +1,4 @@
-# Class which serves shortcuts for UIScreen to schedule screens.
+# Serves shortcuts for easy screen scheduling.
 #
 # Copyright (C) 2017  Red Hat, Inc.
 #
@@ -22,32 +22,36 @@
 from simpleline import App
 
 
-class SchedulerHandler(object):
+class ScreenHandler(object):
 
-    def schedule_screen(self, args=None):
+    @classmethod
+    def schedule_screen(cls, ui_screen, args=None):
         """Schedule screen to the active scheduler.
 
         See: `simpleline.render.screen_scheduler.schedule_screen()`.
         """
-        App.get_scheduler().schedule_screen(ui_screen=self, args=args)
+        App.get_scheduler().schedule_screen(ui_screen=ui_screen, args=args)
 
-    def replace_screen(self, args=None):
+    @classmethod
+    def replace_screen(cls, ui_screen, args=None):
         """Schedule screen to the active scheduler.
 
         See: `simpleline.render.screen_scheduler.replace_screen()`.
         """
-        App.get_scheduler().replace_screen(ui_screen=self, args=args)
+        App.get_scheduler().replace_screen(ui_screen=ui_screen, args=args)
 
-    def push_screen(self, args=None):
+    @classmethod
+    def push_screen(cls, ui_screen, args=None):
         """Schedule screen to the active scheduler.
 
         See: `simpleline.render.screen_scheduler.push_screen()`.
         """
-        App.get_scheduler().push_screen(ui_screen=self, args=args)
+        App.get_scheduler().push_screen(ui_screen=ui_screen, args=args)
 
-    def push_screen_modal(self, args=None):
+    @classmethod
+    def push_screen_modal(cls, ui_screen, args=None):
         """Schedule screen to the active scheduler.
 
         See: `simpleline.render.screen_scheduler.push_screen_modal()`.
         """
-        App.get_scheduler().push_screen_modal(ui_screen=self, args=args)
+        App.get_scheduler().push_screen_modal(ui_screen=ui_screen, args=args)

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -22,6 +22,7 @@ from io import StringIO
 from unittest import mock
 
 from simpleline.render.screen import UIScreen
+from simpleline.render.screen_handler import ScreenHandler
 from tests import schedule_screen_and_run, create_output_with_separators
 
 
@@ -115,10 +116,10 @@ class ShowedCounterScreen(UIScreen):
         super().show_all()
         self.counter += 1
         if self._switch_to_screen is not None:
-            self._switch_to_screen.push_screen()
+            ScreenHandler.push_screen(self._switch_to_screen)
             self._switch_to_screen = None
         elif self._replace_screen is not None:
-            self._replace_screen.replace_screen()
+            ScreenHandler.replace_screen(self._replace_screen)
             self._replace_screen = None
         else:
             self.close()
@@ -154,7 +155,7 @@ class ModalTestScreen(UIScreen):
         if self._modal_screen_refresh is not None:
             # Start a new modal screen
             ModalTestScreen.modal_counter = self.BEFORE_MODAL_REFRESH
-            self._modal_screen_refresh.push_screen_modal()
+            ScreenHandler.push_screen_modal(self._modal_screen_refresh)
             ModalTestScreen.modal_counter = self.AFTER_MODAL_REFRESH
 
     def show_all(self):
@@ -162,7 +163,7 @@ class ModalTestScreen(UIScreen):
         if self._modal_screen_render is not None:
             # Start new modal screen
             ModalTestScreen.modal_counter = self.BEFORE_MODAL_RENDER
-            self._modal_screen_render.push_screen_modal()
+            ScreenHandler.push_screen_modal(self._modal_screen_render)
             ModalTestScreen.modal_counter = self.AFTER_MODAL_RENDER
 
         self.copied_modal_counter = ModalTestScreen.modal_counter
@@ -180,7 +181,7 @@ class EmitDrawThenCreateModal(UIScreen):
         super().refresh(args)
         self.redraw()
         if self._refresh_screen:
-            self._refresh_screen.push_screen_modal()
+            ScreenHandler.push_screen_modal(self._refresh_screen)
             self._refresh_screen = None
 
 


### PR DESCRIPTION
`ScreenScheduler` was renamed to `ScreenHandler` and moved outside of `UIScreen` scope.

Now it feels more like pushing screen to scheduler.

It has every method static and these methods.

Result of this change:
Before:
`screen.push_screen()`

Now:
`ScreenHandler.push_screen(screen)`