### PR TITLE
Add glib event loop

### DIFF
--- a/python-simpleline.spec
+++ b/python-simpleline.spec
@@ -17,6 +17,7 @@ BuildRequires: gettext
 BuildRequires: python3-setuptools
 BuildRequires: intltool
 BuildRequires: python3-pocketlint
+BuildRequires: python3-gobject-base
 
 %description
 Simpleline is a Python library for creating text UI.

--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -69,7 +69,9 @@ class AbstractEventLoop(metaclass=ABCMeta):
         """
         if signal not in self._handlers:
             self._handlers[signal] = []
-        self._handlers[signal].append(EventHandler(callback, data))
+
+        event_handler = self._create_event_handler(callback, data)
+        self._handlers[signal].append(event_handler)
 
     @abstractmethod
     def register_signal_source(self, signal_source):
@@ -143,6 +145,10 @@ class AbstractEventLoop(metaclass=ABCMeta):
         :type args: Anything.
         """
         self._quit_callback = QuitCallback(callback, args)
+
+    def _create_event_handler(self, callback, data):
+        """Create event handler data object and return it."""
+        return EventHandler(callback=callback, data=data)
 
     def _register_wait_on_signal(self, wait_on_signal):
         """Register process waiting on signal `wait_on_signal` and return id for later checking.

--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -120,9 +120,11 @@ class AbstractEventLoop(metaclass=ABCMeta):
         Process signals enqueued by the `self.enqueue_signal()` method. Call handlers registered to the signals by
         the `self.register_signal_handler()` method.
 
-        When `return_after` is specified then wait to the point when this signal is processed. This could be after
-        some more signals was processed because of recursion in calls.
-        Without `return_after` parameter this method will return after all queued signals will be processed.
+        When `return_after` is specified then wait to the point when this signal is processed.
+        NO warranty that this method will return immediately after the signal was processed!
+
+        Without `return_after` parameter this method will return after all queued signals with the highest priority
+        will be processed.
 
         The method is NOT thread safe!
 

--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -49,6 +49,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
         self._quit_callback = None
         # end most inner loop politely by setting to False
         self._run_loop = True
+        self._force_quit = False
 
     def register_signal_handler(self, signal, callback, data=None):
         """Register a callback which will be called when message "event"
@@ -95,6 +96,16 @@ class AbstractEventLoop(metaclass=ABCMeta):
     def run(self):
         """Starts the event loop."""
         log.debug("Starting main loop")
+        self._force_quit = False
+
+    def force_quit(self):
+        """Force quit all running event loops.
+
+        Kill all loop including inner loops (modal window).
+        None of the Simpleline events will be processed anymore.
+        """
+        log.debug("Force quit called. Killing all loops!")
+        self._force_quit = True
 
     @abstractmethod
     def execute_new_loop(self, signal):

--- a/simpleline/event_loop/__init__.py
+++ b/simpleline/event_loop/__init__.py
@@ -25,6 +25,12 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 
 from simpleline.errors import SimplelineError
+from simpleline.event_loop.ticket_machine import TicketMachine
+from simpleline.logging import get_simpleline_logger
+
+log = get_simpleline_logger()
+
+__all__ = ["AbstractEventLoop", "AbstractSignal", "ExitMainLoop"]
 
 QuitCallback = namedtuple("QuitCallback", ["callback", "args"])
 
@@ -37,10 +43,13 @@ class ExitMainLoop(SimplelineError):
 class AbstractEventLoop(metaclass=ABCMeta):
 
     def __init__(self):
-        self._quit_callback = None
         super().__init__()
+        self._handlers = {}
+        self._processed_signals = TicketMachine()
+        self._quit_callback = None
+        # end most inner loop politely by setting to False
+        self._run_loop = True
 
-    @abstractmethod
     def register_signal_handler(self, signal, callback, data=None):
         """Register a callback which will be called when message "event"
         is encountered during process_events.
@@ -49,16 +58,18 @@ class AbstractEventLoop(metaclass=ABCMeta):
         - the received message in the form of (type, [arguments])
         - the data registered with the handler
 
-        :param signal: signal class we want to react on
-        :type signal: class based on the simpleline.event_loop.AbstractSignal class
+        :param signal: Signal class we want to react on.
+        :type signal: Class based on the simpleline.event_loop.AbstractSignal class.
 
-        :param callback: the callback function
+        :param callback: The callback function.
         :type callback: func(event_message, data)
 
-        :param data: optional data to pass to callback
-        :type data: anything
+        :param data: Optional data to pass to callback.
+        :type data: Anything.
         """
-        pass
+        if signal not in self._handlers:
+            self._handlers[signal] = []
+        self._handlers[signal].append(EventHandler(callback, data))
 
     @abstractmethod
     def register_signal_source(self, signal_source):
@@ -73,15 +84,15 @@ class AbstractEventLoop(metaclass=ABCMeta):
     def enqueue_signal(self, signal):
         """Enqueue new event for processing.
 
-        :param signal: signal which you want to add to the event queue for processing
-        :type signal: instance based on AbstractEvent class
+        :param signal: Signal which you want to add to the event queue for processing.
+        :type signal: Instance based on AbstractEvent class.
         """
-        pass
+        log.debug("New signal %s enqueued with source %s", signal, signal.source.__class__.__name__)
 
     @abstractmethod
     def run(self):
         """Starts the event loop."""
-        pass
+        log.debug("Starting main loop")
 
     @abstractmethod
     def execute_new_loop(self, signal):
@@ -89,10 +100,10 @@ class AbstractEventLoop(metaclass=ABCMeta):
 
         This is required for processing a modal screens.
 
-        :param signal: signal passed to the new event loop
-        :type signal: `AbstractSignal` based class
+        :param signal: Signal passed to the new event loop.
+        :type signal: The `AbstractSignal` based class.
         """
-        pass
+        log.debug("Executing inner loop")
 
     @abstractmethod
     def close_loop(self):
@@ -100,7 +111,7 @@ class AbstractEventLoop(metaclass=ABCMeta):
 
         Close an event loop created by the `execute_new_loop()` method.
         """
-        pass
+        log.debug("Closing inner loop")
 
     @abstractmethod
     def process_signals(self, return_after=None):
@@ -130,6 +141,43 @@ class AbstractEventLoop(metaclass=ABCMeta):
         :type args: Anything.
         """
         self._quit_callback = QuitCallback(callback, args)
+
+    def _register_wait_on_signal(self, wait_on_signal):
+        """Register process waiting on signal `wait_on_signal` and return id for later checking.
+
+        ID is returned which is then used in the `self._check_if_signal_processed()` method.
+
+        :param wait_on_signal: Signal we are waiting for.
+        :type wait_on_signal: Class based on `simpleline.event_loop.AbstractSignal`.
+        """
+        return self._processed_signals.take_ticket(wait_on_signal.__name__)
+
+    def _mark_signal_processed(self, signal):
+        """Mark that processes waiting on this signal that they are able to go.
+
+        :param signal: Signal which was processed.
+        :type signal: Class based on `simpleline.event_loop.AbstractSignal`.
+        """
+        self._processed_signals.mark_line_to_go(signal.__class__.__name__)
+
+    def _check_if_signal_processed(self, wait_on_signal, unique_id):
+        """Check if the signal was processed.
+
+        :param wait_on_signal: Signal the process is waiting for.
+        :type wait_on_signal: Class based on `simpleline.event_loop.AbstractSignal`.
+
+        :param unique_id: Unique id returned by the `self._register_wait_on_signal()` method.
+        :type unique_id: int
+        """
+        return self._processed_signals.check_ticket(wait_on_signal.__name__, unique_id)
+
+
+class EventHandler(object):
+    """Data class to save event handlers."""
+
+    def __init__(self, callback, data):
+        self.callback = callback
+        self.data = data
 
 
 class AbstractSignal(metaclass=ABCMeta):

--- a/simpleline/event_loop/event_queue.py
+++ b/simpleline/event_loop/event_queue.py
@@ -94,6 +94,22 @@ class EventQueue(object):
         """
         return self._queue.get()
 
+    def get_top_event_if_priority(self, priority):
+        """Return top enqueued signal if priority is equal to `priority`. Otherwise `None`.
+
+        :param priority: Requested event priority.
+        :type priority: int
+
+        :return: Queued signal if it has requested priority. Otherwise `None`.
+        :rtype: Signal based on class `simpleline.event_loop.signals.AbstractSignal` or `None`.
+        """
+        event = self._queue.get()
+        if event.priority == priority:
+            return event
+        else:
+            self._queue.put(event)
+            return None
+
     def add_source(self, signal_source):
         """Add new source of signals to this queue.
 

--- a/simpleline/event_loop/glib_event_loop.py
+++ b/simpleline/event_loop/glib_event_loop.py
@@ -1,0 +1,215 @@
+# Glib event queue used by Simpleline application.
+#
+# This class is thread safe.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+
+from collections import namedtuple
+
+from simpleline.event_loop import AbstractEventLoop, ExitMainLoop
+from simpleline.event_loop.signals import ExceptionSignal
+
+import gi
+gi.require_version("GLib", "2.0")
+
+from gi.repository import GLib
+from simpleline.logging import get_simpleline_logger
+
+log = get_simpleline_logger()
+
+CallbackArgs = namedtuple("CallbackArgs", ["signal", "source", "handlers"])
+
+
+__all__ = ["GLibEventLoop"]
+
+
+class GLibEventLoop(AbstractEventLoop):
+
+    def __init__(self):
+        super().__init__()
+        # Create first loop
+        loop = GLib.MainLoop()
+        self._event_loops = [EventLoopData(loop)]
+        log.debug("GLib event loop is used!")
+
+    @property
+    def active_main_loop(self):
+        """Return GLib mainloop object."""
+        return self._event_loops[-1].loop
+
+    def register_signal_source(self, signal_source):
+        """Register source of signal for actual event queue.
+
+        :param signal_source: Source for future signals.
+        :type signal_source: `simpleline.render.ui_screen.UIScreen`
+        """
+        super().register_signal_source(signal_source)
+        loop_data = self._event_loops[-1]
+        loop_data.sources.add(signal_source)
+
+    def enqueue_signal(self, signal):
+        """Enqueue new event for processing.
+
+        :param signal: signal which you want to add to the event queue for processing
+        :type signal: instance based on AbstractEvent class
+        """
+        super().enqueue_signal(signal)
+        loop_data = self._find_loop_data_for_source(signal.source)
+        self._register_handlers_to_loop(loop_data.loop, signal)
+
+    def _find_loop_data_for_source(self, source):
+        """Find event loop belonging to this signal source."""
+        for loop_data in reversed(self._event_loops):
+            if source in loop_data.sources:
+                return loop_data
+
+        return self._event_loops[-1]
+
+    def _register_handlers_to_loop(self, event_loop, signal):
+        """Register handlers to the event loop."""
+        context = event_loop.get_context()
+        handlers = []
+
+        if type(signal) in self._handlers:
+            handlers = self._handlers[type(signal)]
+        elif type(signal) is ExceptionSignal:
+            handlers = [self._raise_exception]
+
+        # GLib event source which contains handler callback
+        # Every source can hold only one callback
+        source = GLib.idle_source_new()
+        source.set_priority(signal.priority)
+        data = CallbackArgs(signal, source, handlers)
+
+        source.set_callback(self._run_handlers, data)
+        # attach source to the event loop
+        source.attach(context)
+
+    def _run_handlers(self, data):
+        """Run handlers attached to this signal and clean source afterwards."""
+        signal = data.signal
+        source = data.source
+        handlers = data.handlers
+
+        try:
+            for handler in handlers:
+                handler.callback(signal, handler.data)
+        except ExitMainLoop:
+            self._quit_all_loops()
+
+        # based on GLib documentation we should clean source
+        # source will be removed from event loop context this way
+        source.destroy()
+
+        self._mark_signal_processed(signal)
+
+    def _raise_exception(self, data):
+        signal = data.signal
+        self._quit_all_loops()
+
+        raise signal.exception_info[0] from signal.exception_info[1]
+
+    def _quit_all_loops(self):
+        for loop_data in reversed(self._event_loops):
+            loop_data.loop.quit()
+
+    def run(self):
+        """Starts the event loop."""
+        super().run()
+        if len(self._event_loops) != 1:
+            raise ValueError("Can't run event loop multiple times.")
+
+        self._event_loops[0].loop.run()
+        log.debug("Main loop ended. Running callback if set.")
+
+        if self._quit_callback:
+            cb = self._quit_callback.callback
+            cb(self._quit_callback.args)
+
+    def execute_new_loop(self, signal):
+        """Starts the new event loop and pass `signal` in it.
+
+        This is required for processing a modal screens.
+
+        :param signal: signal passed to the new event loop
+        :type signal: `AbstractSignal` based class
+        """
+        super().execute_new_loop(signal)
+
+        new_context = GLib.MainContext()
+        new_loop = GLib.MainLoop(new_context)
+        loop_data = EventLoopData(new_loop)
+        self._event_loops.append(loop_data)
+
+        self.enqueue_signal(signal)
+        new_loop.run()
+
+    def close_loop(self):
+        """Close active event loop.
+
+        Close an event loop created by the `execute_new_loop()` method.
+        """
+        super().close_loop()
+        old_loop_data = self._event_loops.pop()
+        old_loop_data.loop.quit()
+
+    def process_signals(self, return_after=None):
+        """This method processes incoming async messages.
+
+        Process signals enqueued by the `self.enqueue_signal()` method. Call handlers registered to the signals by
+        the `self.register_signal_handler()` method.
+
+        When `return_after` is specified then wait to the point when this signal is processed.
+        NO warranty that this method will return immediately after the signal was processed!
+
+        Without `return_after` parameter this method will return after all queued signals with the highest priority
+        will be processed.
+
+        The method is NOT thread safe!
+
+        :param return_after: Wait on this signal to be processed.
+        :type return_after: Class of the signal.
+        """
+        super().process_signals(return_after)
+        loop_data = self._event_loops[-1]
+
+        if return_after is not None:
+            ticket_id = self._register_wait_on_signal(return_after)
+
+            while not self._check_if_signal_processed(return_after, ticket_id):
+                self._iterate_event_loop(loop_data.loop)
+
+        else:
+            self._iterate_event_loop(loop_data.loop)
+
+    def _iterate_event_loop(self, event_loop):
+        context = event_loop.get_context()
+        # This is useful for tests
+        wait_on_timeout = False
+        context.iteration(wait_on_timeout)
+
+
+class EventLoopData(object):
+
+    def __init__(self, loop):
+        super().__init__()
+        self.loop = loop
+        self.sources = set()
+

--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -220,6 +220,8 @@ class MainLoop(AbstractEventLoop):
                     handler_data.callback(signal, handler_data.data)
                 except ExitMainLoop:
                     raise
+                except Exception:  # pylint: disable=broad-except
+                    self.enqueue_signal(ExceptionSignal(self))
         elif type(signal) is ExceptionSignal:
             self._raise_exception(signal)
 

--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -161,7 +161,7 @@ class MainLoop(AbstractEventLoop):
         # run infinite loop
         # this will always wait on input processing or similar so it should not busy waiting
         while self._run_loop:
-            self.process_signals()
+            self._process_signals_loop()
 
         # set back to True to leave outer loop working
         self._run_loop = True
@@ -181,13 +181,21 @@ class MainLoop(AbstractEventLoop):
         :param return_after: Wait on this signal to be processed.
         :type return_after: Class of the signal.
         """
+        if return_after is not None:
+            self._process_signals_with_return(return_after)
+        else:
+            self._process_signals_iteration()
+
+    def _process_signals_with_return(self, return_after):
+        """Process signals until the return_after signal was processed.
+
+        Or the loop quited.
+        """
         # get unique ID when waiting for the signal
         unique_id = self._register_wait_on_signal(return_after)
 
-        while self._can_process_signals() or return_after is not None:
+        while self._run_loop:
             signal = self._active_queue.get()
-            # all who is waiting on this signal can stop waiting
-            self._mark_signal_processed(signal)
 
             # do the signal processing (call handlers)
             self._process_signal(signal)
@@ -196,12 +204,23 @@ class MainLoop(AbstractEventLoop):
             if self._check_if_signal_processed(return_after, unique_id):
                 return
 
-    def _can_process_signals(self):
-        """To proceed signal processing, these conditions must be true."""
-        return not self._active_queue.empty() and self._run_loop
+    def _process_signals_iteration(self):
+        """Process queued signal and then return."""
+        while not self._active_queue.empty() and self._run_loop:
+            signal = self._active_queue.get()
+            self._process_signal(signal)
+
+    def _process_signals_loop(self):
+        """Process signal until the event loop quited."""
+        while self._run_loop:
+            signal = self._active_queue.get()
+            self._process_signal(signal)
 
     def _process_signal(self, signal):
         log.debug("Processing signal %s", signal)
+
+        self._mark_signal_processed(signal)
+
         if type(signal) in self._handlers:
             for handler_data in self._handlers[type(signal)]:
                 try:
@@ -215,9 +234,6 @@ class MainLoop(AbstractEventLoop):
         raise signal.exception_info[0] from signal.exception_info[1]
 
     def _register_wait_on_signal(self, wait_on_signal):
-        if wait_on_signal is None:
-            return -1
-
         return self._processed_signals.take_ticket(wait_on_signal.__name__)
 
     def _mark_signal_processed(self, signal):

--- a/simpleline/event_loop/signals.py
+++ b/simpleline/event_loop/signals.py
@@ -73,10 +73,5 @@ class RenderScreenSignal(AbstractSignal):
     pass
 
 
-class InputScreenSignal(AbstractSignal):
-    """Input is required by the screen."""
-    pass
-
-
 class CloseScreenSignal(AbstractSignal):
     """Close current screen."""

--- a/simpleline/event_loop/ticket_machine.py
+++ b/simpleline/event_loop/ticket_machine.py
@@ -1,0 +1,75 @@
+# Ticket machine synchronization class.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+
+
+class TicketMachine(object):
+    """Hold signals processed by the event loop if someone wait on them.
+
+    This is useful when recursive process events will skip required signal.
+    """
+
+    def __init__(self):
+        self._lines = {}
+        self._counter = 0
+
+    def take_ticket(self, line_id):
+        """Take ticket (id) and go line (processing events).
+
+        Use `check_ticket` if you are ready to go.
+
+        :param line_id: Line where you are waiting.
+        :type line_id: Anything.
+        """
+        obj_id = self._counter
+        if line_id not in self._lines:
+            self._lines[line_id] = {obj_id: False}
+        else:
+            self._lines[line_id][obj_id] = False
+
+        self._counter += 1
+        return obj_id
+
+    def check_ticket(self, line, unique_id):
+        """Check if you are ready to go.
+
+        If True the unique_id is not valid anymore.
+
+        :param unique_id: Your id used to identify you in the line.
+        :type unique_id: int
+
+        :param line: Line where you are waiting.
+        :type line: Anything.
+        """
+        if self._lines[line][unique_id]:
+            return self._lines[line].pop(unique_id)
+
+    def mark_line_to_go(self, line):
+        """All in the `line` are ready to go.
+
+        Mark all tickets in the line as True.
+
+        :param line: Line which should processed.
+        :type line: Anything.
+        """
+        if line in self._lines:
+            our_line = self._lines[line]
+            for key in our_line:
+                our_line[key] = True

--- a/simpleline/render/io_manager.py
+++ b/simpleline/render/io_manager.py
@@ -36,9 +36,6 @@ from simpleline.logging import get_simpleline_logger
 log = get_simpleline_logger()
 
 
-RAW_INPUT_LOCK = threading.Lock()
-
-
 class InOutManager(object):
 
     def __init__(self, event_loop):
@@ -48,6 +45,7 @@ class InOutManager(object):
         :type event_loop: Class based on `simpleline.event_loop.AbstractEventLoop`.
         """
         super().__init__()
+        self._input_lock = threading.Lock()
         self._input_error_counter = 0
         self._input_error_threshold = 5
         self._input_thread = None
@@ -208,7 +206,7 @@ class InOutManager(object):
             lines = widget.get_lines()
             sys.stdout.write("\n".join(lines) + " ")
             sys.stdout.flush()
-            if not RAW_INPUT_LOCK.acquire(False):
+            if not self._input_lock.acquire(False):
                 # raw_input is already running
                 return
             else:
@@ -218,7 +216,7 @@ class InOutManager(object):
                 except EOFError:
                     data = ""
                 finally:
-                    RAW_INPUT_LOCK.release()
+                    self._input_lock.release()
 
         self._event_loop.enqueue_signal(InputReadySignal(self, data))
 

--- a/simpleline/render/io_manager.py
+++ b/simpleline/render/io_manager.py
@@ -55,6 +55,7 @@ class InOutManager(object):
         self._spacer = ""
         self._calculate_spacer()
         self._user_input = ""
+        self._user_input_callback = None
 
         # save user input
         self._event_loop.register_signal_handler(InputReadySignal, self._user_input_received_handler)
@@ -89,6 +90,15 @@ class InOutManager(object):
 
     def _user_input_received_handler(self, signal, args):
         self._user_input = signal.data
+        # wait for the input thread to finish
+        self._input_thread.join()
+
+        # call async callback
+        if self._user_input_callback is not None:
+            cb = self._user_input_callback
+            self._user_input_callback = None
+
+            cb(self._user_input)
 
     def set_pass_func(self, getpass_func):
         """Set a function for getting passwords."""
@@ -111,7 +121,7 @@ class InOutManager(object):
         except Exception:    # pylint: disable=broad-except
             self._event_loop.enqueue_signal(ExceptionSignal(self))
 
-    def process_input(self, active_screen):
+    def process_input(self, active_screen, user_input):
         """Process input from the screens.
 
         Result of the processing is saved in the `processed_result` property.
@@ -119,30 +129,43 @@ class InOutManager(object):
         :param active_screen: Screen demanding this input processing.
         :type active_screen: Classed based on `simpleline.render.screen.UIScreen`.
 
+        :param user_input: User input string.
+        :type user_input: String.
+
         :raises: ExitMainLoop or any other kind of exception from screen processing.
 
         :return: Return data object with result status and state.
         :rtype: `simpleline.render.in_out_manager.UserInputResult` class.
         """
-        last_screen = active_screen.ui_screen
-        # get the screen's prompt
-        prompt = last_screen.prompt(active_screen.args)
-
-        # None means prompt handled the input by itself -> continue
-        if prompt is None:
-            return UserInputResult.PROCESSED
-
-        # get the input from user
-        c = self.get_user_input(prompt)
-
         # process the input, if it wasn't processed (valid)
         # increment the error counter
-        result = self._process_input(active_screen, c)
+        result = self._process_input(active_screen, user_input)
         if result.was_successful():
             self._input_error_counter = 0
         else:
             self._input_error_counter += 1
         return result
+
+    def get_user_input_async(self, prompt, callback, hidden=False):
+        """Reads user input asynchronously.
+
+        User input will be retrieved by `simpleline.event_loop.signals.InputReadySignal` and then passed to
+        the `callback` argument.
+
+        :param prompt: Ask user what you want to get.
+        :type prompt: String or Prompt instance.
+
+        :param callback: Callback which will get user input as the only parameter.
+        :type callback: Function with one parameter key.
+
+        :param hidden: Hide echo of the keys from user.
+        :type hidden: bool
+        """
+        if self._is_input_expected(prompt):
+            self._user_input_callback = callback
+
+            self._check_input_thread_running()
+            self._start_user_input_async(prompt, hidden)
 
     def get_user_input(self, prompt, hidden=False):
         """Reads user input.
@@ -159,10 +182,13 @@ class InOutManager(object):
         :returns: User input.
         :rtype: str
         """
-        if self._input_thread is not None and self._input_thread.is_alive():
-            raise KeyError("Can't run multiple input threads at the same time!")
+        if not self._is_input_expected(prompt):
+            return ""
 
-        return self._get_user_input(prompt, hidden)
+        self._check_input_thread_running()
+
+        self._start_user_input_async(prompt, hidden)
+        return self._wait_on_user_input()
 
     def get_user_input_without_check(self, prompt, hidden=False):
         """Reads user input without checking if someone is already waiting for input.
@@ -175,15 +201,37 @@ class InOutManager(object):
 
         See `get_user_input()` method.
         """
-        return self._get_user_input(prompt, hidden)
+        if self._is_input_expected(prompt):
+            self._start_user_input_async(prompt, hidden)
+            return self._wait_on_user_input()
 
-    def _get_user_input(self, prompt, hidden):
+    def _check_input_thread_running(self):
+        if self._input_thread is not None and self._input_thread.is_alive():
+            raise KeyError("Can't run multiple input threads at the same time!")
+
+    def _is_input_expected(self, prompt):
+        """Check if user handled input processing some other way.
+
+        Do nothing if user did handled user input.
+
+        :returns: True if prompt is set and we can use it to get user input.
+                  False if prompt is not available, which means that user handled input on their own.
+        """
+        # None means prompt handled the input by itself -> continue
+        if prompt is None:
+            self._input_error_counter = 0
+            return False
+        else:
+            return True
+
+    def _start_user_input_async(self, prompt, hidden):
         self._input_thread = threading.Thread(target=self._thread_input, name="InputThread",
                                               args=(prompt, hidden))
         self._input_thread.daemon = True
         self._input_thread.start()
+
+    def _wait_on_user_input(self):
         self._event_loop.process_signals(InputReadySignal)
-        self._input_thread.join()
         return self._user_input  # return the user input
 
     def _thread_input(self, prompt, hidden):

--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -22,8 +22,7 @@
 import threading
 
 from simpleline.event_loop import ExitMainLoop
-from simpleline.event_loop.signals import ExceptionSignal, RenderScreenSignal, InputScreenSignal, \
-                                          CloseScreenSignal
+from simpleline.event_loop.signals import ExceptionSignal, RenderScreenSignal, CloseScreenSignal
 from simpleline.render import RenderUnexpectedError
 from simpleline.render.io_manager import InOutManager, UserInputResult
 from simpleline.render.screen_stack import ScreenStack, ScreenData, ScreenStackEmptyException
@@ -60,7 +59,6 @@ class ScreenScheduler(object):
 
     def _register_handlers(self):
         self._event_loop.register_signal_handler(RenderScreenSignal, self._process_screen_callback)
-        self._event_loop.register_signal_handler(InputScreenSignal, self._process_input_callback)
         self._event_loop.register_signal_handler(CloseScreenSignal, self._close_screen_callback)
 
     @property
@@ -247,16 +245,17 @@ class ScreenScheduler(object):
 
     def input_required(self):
         """Register user input to the event loop for processing."""
-        self._event_loop.enqueue_signal(InputScreenSignal(self))
+        top_screen = self._get_last_screen()
+        ui_screen = top_screen.ui_screen
+        prompt = ui_screen.prompt(top_screen.args)
 
-    def _process_input_callback(self, signal, data):
-        self._process_input()
+        self._io_manager.get_user_input_async(prompt, self._process_input)
 
-    def _process_input(self):
+    def _process_input(self, user_input):
         active_screen = self._get_last_screen()
 
         try:
-            input_result = self._io_manager.process_input(active_screen)
+            input_result = self._io_manager.process_input(active_screen, user_input)
         except ExitMainLoop:
             raise
         except Exception:    # pylint: disable=broad-except

--- a/tests/event_loop_test.py
+++ b/tests/event_loop_test.py
@@ -19,11 +19,10 @@
 
 import unittest
 
-from simpleline.event_loop.main_loop import EventHandler
-from simpleline.event_loop.main_loop import MainLoop
 from simpleline.event_loop import AbstractSignal
-
+from simpleline.event_loop import EventHandler
 from simpleline.event_loop import ExitMainLoop
+from simpleline.event_loop.main_loop import MainLoop
 
 
 class EventLoopHandler_TestCase(unittest.TestCase):
@@ -54,11 +53,15 @@ class ProcessEvents_TestCase(unittest.TestCase):
         self.signal_counter_copied = 0
         self.callback_called = False
         self.callback_args = None
+        self.create_loop()
+
+    def create_loop(self):
+        self.loop = MainLoop()
 
     def test_simple_register_handler(self):
         self.callback_called = False
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_callback)
         loop.enqueue_signal(TestSignal())
         loop.process_signals()
@@ -68,7 +71,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
     def test_process_more_signals(self):
         self.signal_counter = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.enqueue_signal(TestSignal())
         loop.enqueue_signal(TestSignal())
@@ -80,7 +83,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
     def test_process_signals_multiple_times(self):
         self.signal_counter = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.enqueue_signal(TestSignal())
         loop.enqueue_signal(TestSignal())
@@ -95,7 +98,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
     def test_wait_on_signal(self):
         self.signal_counter = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.enqueue_signal(TestSignal())
         loop.enqueue_signal(TestSignal2())
@@ -109,7 +112,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
     def test_wait_on_signal_skipped_by_inner_process_events(self):
         self.signal_counter = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         # run process signals recursively in this handler which will skip processing
         loop.register_signal_handler(TestSignal2, self._handler_process_events_then_register_testsignal, loop)
@@ -125,7 +128,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
         self.signal_counter = 0
         self.signal_counter2 = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.register_signal_handler(TestSignal, self._handler_signal_counter2)
         loop.enqueue_signal(TestSignal())
@@ -139,7 +142,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
         self.signal_counter = 0
         self.signal_counter_copied = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.register_signal_handler(TestPrioritySignal, self._handler_signal_copy_counter)
         loop.enqueue_signal(TestSignal())
@@ -155,7 +158,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
         self.signal_counter = 0
         self.signal_counter_copied = 0
 
-        loop = MainLoop()
+        loop = self.loop
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
         loop.register_signal_handler(TestLowPrioritySignal, self._handler_signal_copy_counter)
         loop.enqueue_signal(TestSignal())
@@ -172,7 +175,7 @@ class ProcessEvents_TestCase(unittest.TestCase):
         self.callback_args = None
         msg = "Test data"
 
-        loop = MainLoop()
+        loop = self.loop
         loop.set_quit_callback(self._handler_quit_callback, args=msg)
         loop.register_signal_handler(TestSignal, self._handler_raise_ExitMainLoop_exception)
         loop.enqueue_signal(TestSignal())

--- a/tests/event_loop_test.py
+++ b/tests/event_loop_test.py
@@ -111,11 +111,11 @@ class ProcessEvents_TestCase(unittest.TestCase):
 
         loop = MainLoop()
         loop.register_signal_handler(TestSignal, self._handler_signal_counter)
-        # run process signals recursively in this handler which will skip processing for wait_on_signal
+        # run process signals recursively in this handler which will skip processing
         loop.register_signal_handler(TestSignal2, self._handler_process_events_then_register_testsignal, loop)
         loop.enqueue_signal(TestSignal2())
         loop.enqueue_signal(TestSignal())
-        # new signal will be registered in handler method but that shouldn't be processed by wait_on_signal
+        # new signal will be registered in handler method but that shouldn't be processed
         # because it should end on the first signal even when it was skipped
         loop.process_signals(return_after=TestSignal)
 

--- a/tests/glib_event_loop_test.py
+++ b/tests/glib_event_loop_test.py
@@ -1,0 +1,57 @@
+# Event loop test classes.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from simpleline.event_loop.glib_event_loop import GLibEventLoop
+from tests.event_loop_test import ProcessEvents_TestCase
+
+import gi
+gi.require_version("GLib", "2.0")
+
+from gi.repository import GLib
+
+
+class GLibProcessEvents_TestCase(ProcessEvents_TestCase):
+    """Run all the tests in ProcessEvents test case but with GLib event loop."""
+
+    def setUp(self):
+        super().setUp()
+        self.timeout_error = False
+
+    def tearDown(self):
+        super().tearDown()
+        if self.timeout_error:
+            raise AssertionError("Loop was killed by timeout!")
+
+    def _quit_loop(self, loop):
+        """Kill GLib loop."""
+        loop.quit()
+        self.timeout_error = True
+        return True
+
+    def create_loop(self):
+        self.loop = GLibEventLoop()
+        # Kill the loop every 3 seconds
+        # This is prevention from running loop indefinitely
+
+        loop = self.loop.active_main_loop
+        context = loop.get_context()
+
+        source = GLib.timeout_source_new_seconds(2)
+        source.set_callback(self._quit_loop, loop)
+        source.attach(context)

--- a/tests/glib_tests/event_loop_glib_test.py
+++ b/tests/glib_tests/event_loop_glib_test.py
@@ -1,4 +1,4 @@
-# Helper functions for the test classes.
+# Event loop test classes for GLib implementation.
 #
 # Copyright (C) 2017  Red Hat, Inc.
 #
@@ -17,25 +17,16 @@
 # Red Hat, Inc.
 #
 
-from simpleline import App
+from tests.event_loop_test import ProcessEvents_TestCase
+from tests.glib_tests import GLibUtilityMixin
 
 
-class UtilityMixin(object):
+class GLibProcessEvents_TestCase(ProcessEvents_TestCase, GLibUtilityMixin):
+    """Run all the tests in ProcessEvents test case but with GLib event loop."""
 
-    def calculate_separator(self, width=80):
-        separator = "\n".join(2 * [width * "="])
-        separator += "\n"  # print adds another newline
-        return separator
+    def tearDown(self):
+        super().tearDown()
+        self.teardown_glib()
 
-    def create_output_with_separators(self, screens_text):
-        msg = ""
-        for screen_txt in screens_text:
-            msg += self.calculate_separator()
-            msg += screen_txt + "\n\n"
-
-        return msg
-
-    def schedule_screen_and_run(self, screen):
-        App.initialize()
-        App.get_scheduler().schedule_screen(screen)
-        App.run()
+    def create_loop(self):
+        self.create_glib_loop()

--- a/tests/glib_tests/render_screen_glib_test.py
+++ b/tests/glib_tests/render_screen_glib_test.py
@@ -1,4 +1,4 @@
-# Helper functions for the test classes.
+# Rendering screen test classes for GLib implementation.
 #
 # Copyright (C) 2017  Red Hat, Inc.
 #
@@ -17,25 +17,37 @@
 # Red Hat, Inc.
 #
 
+
+from tests.render_screen_test import SimpleUIScreenProcessing_TestCase, InputProcessing_TestCase
+from tests.glib_tests import GLibUtilityMixin
+
 from simpleline import App
 
 
-class UtilityMixin(object):
+class GLibSimpleUIScreenProcessing_TestCase(SimpleUIScreenProcessing_TestCase, GLibUtilityMixin):
+    """Run all the tests in ProcessEvents test case but with GLib event loop."""
 
-    def calculate_separator(self, width=80):
-        separator = "\n".join(2 * [width * "="])
-        separator += "\n"  # print adds another newline
-        return separator
+    def setUp(self):
+        super().setUp()
+        self.loop = None
+        self.timeout_error = False
 
-    def create_output_with_separators(self, screens_text):
-        msg = ""
-        for screen_txt in screens_text:
-            msg += self.calculate_separator()
-            msg += screen_txt + "\n\n"
-
-        return msg
+    def tearDown(self):
+        super().tearDown()
+        self.teardown_glib()
 
     def schedule_screen_and_run(self, screen):
-        App.initialize()
-        App.get_scheduler().schedule_screen(screen)
-        App.run()
+        self.schedule_screen_and_run_with_glib(screen)
+
+
+class GLibInputProcessing_TestCase(InputProcessing_TestCase, GLibUtilityMixin):
+
+    def setUp(self):
+        super().setUp()
+        # re-initialize with GLib event loop
+        loop = self.create_glib_loop()
+        App.initialize(event_loop=loop)
+
+    def tearDown(self):
+        super().tearDown()
+        self.teardown_glib()

--- a/tests/glib_tests/screen_scheduler_glib_test.py
+++ b/tests/glib_tests/screen_scheduler_glib_test.py
@@ -1,4 +1,4 @@
-# Helper functions for the test classes.
+# Screen scheduling GLib test classes.
 #
 # Copyright (C) 2017  Red Hat, Inc.
 #
@@ -17,25 +17,21 @@
 # Red Hat, Inc.
 #
 
-from simpleline import App
+
+from tests.screen_scheduler_test import ScreenScheduler_TestCase
+from tests.glib_tests import GLibUtilityMixin
 
 
-class UtilityMixin(object):
+class GLibScrenScheduler_TestCase(ScreenScheduler_TestCase, GLibUtilityMixin):
 
-    def calculate_separator(self, width=80):
-        separator = "\n".join(2 * [width * "="])
-        separator += "\n"  # print adds another newline
-        return separator
+    def setUp(self):
+        super().setUp()
+        self.loop = None
+        self.timeout_error = False
 
-    def create_output_with_separators(self, screens_text):
-        msg = ""
-        for screen_txt in screens_text:
-            msg += self.calculate_separator()
-            msg += screen_txt + "\n\n"
-
-        return msg
+    def tearDown(self):
+        super().tearDown()
+        self.teardown_glib()
 
     def schedule_screen_and_run(self, screen):
-        App.initialize()
-        App.get_scheduler().schedule_screen(screen)
-        App.run()
+        self.schedule_screen_and_run_with_glib(screen)

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -25,7 +25,7 @@ from unittest import mock
 from simpleline import App
 from simpleline.render import RenderUnexpectedError
 from simpleline.render.screen import UIScreen, InputState
-from tests import schedule_screen_and_run, calculate_separator
+from tests import UtilityMixin
 
 
 def _fake_input(queue_instance, prompt, hidden):
@@ -33,14 +33,14 @@ def _fake_input(queue_instance, prompt, hidden):
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
-class SeparatorPrinting_TestCase(unittest.TestCase):
+class SeparatorPrinting_TestCase(unittest.TestCase, UtilityMixin):
 
     def test_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
 
-        schedule_screen_and_run(ui_screen)
+        self.schedule_screen_and_run(ui_screen)
 
-        self.assertEqual(calculate_separator(), stdout_mock.getvalue())
+        self.assertEqual(self.calculate_separator(), stdout_mock.getvalue())
 
     def test_other_width_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
@@ -51,7 +51,7 @@ class SeparatorPrinting_TestCase(unittest.TestCase):
         App.get_scheduler().schedule_screen(ui_screen)
         App.run()
 
-        self.assertEqual(calculate_separator(width), stdout_mock.getvalue())
+        self.assertEqual(self.calculate_separator(width), stdout_mock.getvalue())
 
     def test_no_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
@@ -100,15 +100,15 @@ class SimpleUIScreenFeatures_TestCase(unittest.TestCase):
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
-class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
+class SimpleUIScreenProcessing_TestCase(unittest.TestCase, UtilityMixin):
 
     def setUp(self):
-        self._default_separator = calculate_separator(80)
+        self._default_separator = self.calculate_separator(80)
 
     def test_screen_event_loop_processing(self, _):
         ui_screen = EmptyScreen()
 
-        schedule_screen_and_run(ui_screen)
+        self.schedule_screen_and_run(ui_screen)
 
         self.assertTrue(ui_screen.is_closed)
 
@@ -132,7 +132,7 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
         screen = NoInputScreen()
         screen.title = u"TestTitle"
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         out = self._default_separator
         out += "TestTitle\n\n"
@@ -143,25 +143,25 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
         input_mock.return_value = "a"
         screen = InputScreen()
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertTrue(screen.input_processed)
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
-class ScreenException_TestCase(unittest.TestCase):
+class ScreenException_TestCase(unittest.TestCase, UtilityMixin):
 
     def test_raise_exception_in_refresh(self, _):
         screen = ExceptionTestScreen(ExceptionTestScreen.REFRESH)
 
         with self.assertRaises(TestRefreshException):
-            schedule_screen_and_run(screen)
+            self.schedule_screen_and_run(screen)
 
     def test_raise_exception_in_rendering(self, _):
         screen = ExceptionTestScreen(ExceptionTestScreen.REDRAW)
 
         with self.assertRaises(TestRedrawException):
-            schedule_screen_and_run(screen)
+            self.schedule_screen_and_run(screen)
 
 
 @mock.patch('sys.stdout')
@@ -177,11 +177,12 @@ class InputProcessing_TestCase(unittest.TestCase):
         self.pass_called = False
         self.pass_prompt = None
 
+        App.initialize()
+
     def test_quit_input(self, mock_stdin, mock_stdout):
         mock_stdin.return_value = "q"
         screen = UIScreen()
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.run()
 
@@ -190,7 +191,6 @@ class InputProcessing_TestCase(unittest.TestCase):
         screen = UIScreen()
         screen2 = EmptyScreen()
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.get_scheduler().schedule_screen(screen2)
         App.run()
@@ -202,7 +202,6 @@ class InputProcessing_TestCase(unittest.TestCase):
         mock_stdin.return_value = "r"
         screen = RefreshTestScreen()
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.run()
 
@@ -213,7 +212,6 @@ class InputProcessing_TestCase(unittest.TestCase):
         threshold = 5
         screen = InputErrorTestScreen(threshold)
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.run()
 
@@ -225,7 +223,6 @@ class InputProcessing_TestCase(unittest.TestCase):
         threshold = 12
         screen = InputErrorTestScreen(threshold)
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.run()
 
@@ -235,7 +232,6 @@ class InputProcessing_TestCase(unittest.TestCase):
     def test_input_no_prompt(self, mock_stdin, mock_stdout):
         screen = InputWithNoPrompt()
 
-        App.initialize()
         App.get_scheduler().schedule_screen(screen)
         App.run()
 
@@ -244,7 +240,7 @@ class InputProcessing_TestCase(unittest.TestCase):
     @mock.patch('simpleline.event_loop.main_loop.MainLoop.process_signals')
     def test_custom_getpass(self, mock_stdin, mock_stdout, process_signals):
         prompt = mock.MagicMock()
-        App.initialize()
+
         App.get_scheduler().io_manager.set_pass_func(self._test_getpass)
         App.get_scheduler().io_manager.get_user_input(prompt=prompt, hidden=True)
 

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -138,7 +138,7 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
         out += "TestTitle\n\n"
         self.assertEqual(stdout_mock.getvalue(), out)
 
-    @mock.patch('simpleline.render.io_manager.InOutManager.get_user_input')
+    @mock.patch('simpleline.render.io_manager.InOutManager._get_input')
     def test_basic_input(self, input_mock, _):
         input_mock.return_value = "a"
         screen = InputScreen()

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -23,17 +23,17 @@ from unittest import mock
 
 from simpleline.render.screen import UIScreen
 from simpleline.render.screen_handler import ScreenHandler
-from tests import schedule_screen_and_run, create_output_with_separators
+from tests import UtilityMixin
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)
-class ScreenScheduler_TestCase(unittest.TestCase):
+class ScreenScheduler_TestCase(unittest.TestCase, UtilityMixin):
 
     def test_replace_screen(self, _):
         replace_screen = ShowedCounterScreen()
         screen = ShowedCounterScreen(replace_screen=replace_screen)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.counter, 1)
         self.assertEqual(replace_screen.counter, 1)
@@ -42,7 +42,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         switched_screen = ShowedCounterScreen()
         screen = ShowedCounterScreen(switched_screen)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.counter, 2)
         self.assertEqual(switched_screen.counter, 1)
@@ -51,7 +51,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         modal_screen = ModalTestScreen()
         screen = ModalTestScreen(modal_screen_render=modal_screen)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_RENDER)
         self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_RENDER)
@@ -60,7 +60,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         modal_screen = ModalTestScreen()
         screen = ModalTestScreen(modal_screen_refresh=modal_screen)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_REFRESH)
         self.assertEqual(modal_screen.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_REFRESH)
@@ -70,7 +70,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         modal_render = ModalTestScreen()
         screen = ModalTestScreen(modal_screen_refresh=modal_refresh, modal_screen_render=modal_render)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_RENDER)
         self.assertEqual(modal_refresh.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_REFRESH)
@@ -81,7 +81,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         modal_render_outer = ModalTestScreen(modal_screen_render=modal_render_inner)
         screen = ModalTestScreen(modal_screen_render=modal_render_outer)
 
-        schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
 
         self.assertEqual(screen.copied_modal_counter, ModalTestScreen.AFTER_MODAL_RENDER)
         # outer modal screen has AFTER_MODAL_RENDER because it was set before by inner loop
@@ -97,10 +97,10 @@ class ScreenScheduler_TestCase(unittest.TestCase):
                     "Parent",   # draw enqueued draw signal -- manually registered in refresh()
                     "Parent"]   # draw because modal screen was closed
 
-        schedule_screen_and_run(parent_screen)
+        self.schedule_screen_and_run(parent_screen)
 
         self.maxDiff = None
-        self.assertEqual(create_output_with_separators(expected), mock_stdout.getvalue())
+        self.assertEqual(self.create_output_with_separators(expected), mock_stdout.getvalue())
 
 
 class ShowedCounterScreen(UIScreen):

--- a/tests/screen_scheduler_test.py
+++ b/tests/screen_scheduler_test.py
@@ -88,7 +88,7 @@ class ScreenScheduler_TestCase(unittest.TestCase):
         self.assertEqual(modal_render_outer.copied_modal_counter, ModalTestScreen.AFTER_MODAL_RENDER)
         self.assertEqual(modal_render_inner.copied_modal_counter, ModalTestScreen.BEFORE_MODAL_RENDER)
 
-    @mock.patch('simpleline.render.io_manager.InOutManager.get_user_input')
+    @mock.patch('simpleline.render.io_manager.InOutManager._get_input')
     def test_switch_screen_modal_input_order(self, mock_input, mock_stdout):
         modal_screen = InputAndDrawScreen("Modal")
         parent_screen = EmitDrawThenCreateModal(modal_screen, msg="Parent")
@@ -176,13 +176,16 @@ class EmitDrawThenCreateModal(UIScreen):
         super().__init__()
         self._refresh_screen = refresh_screen
         self.title = msg
+        self.input_required = False
 
     def refresh(self, args=None):
         super().refresh(args)
-        self.redraw()
         if self._refresh_screen:
+            self.redraw()
             ScreenHandler.push_screen_modal(self._refresh_screen)
             self._refresh_screen = None
+        else:
+            self.close()
 
 
 class InputAndDrawScreen(UIScreen):
@@ -190,3 +193,8 @@ class InputAndDrawScreen(UIScreen):
     def __init__(self, msg):
         super().__init__()
         self.title = msg
+        self.input_required = False
+
+    def refresh(self, args=None):
+        super().refresh(args)
+        self.close()

--- a/tests/ticket_machine_test.py
+++ b/tests/ticket_machine_test.py
@@ -19,7 +19,7 @@
 
 from unittest import TestCase
 
-from simpleline.event_loop.main_loop import TicketMachine
+from simpleline.event_loop.ticket_machine import TicketMachine
 
 
 class TicketMachine_TestCase(TestCase):


### PR DESCRIPTION
Most of the related old tests are also used GLib event loop.

This event loop is not required by the Simpleline package. You do not need to use it and if you want to use it, please add it as requires for your package / install it manually. 