### PR TITLE
Redraw on first scheduled screen (#1487326)

### DIFF
--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -56,7 +56,7 @@ class ScreenScheduler(object):
             self._screen_stack = ScreenStack()
         self._register_handlers()
 
-        self.redraw()
+        self._first_screen_scheduled = False
 
     def _register_handlers(self):
         self._event_loop.register_signal_handler(RenderScreenSignal, self._process_screen_callback)
@@ -108,6 +108,12 @@ class ScreenScheduler(object):
         log.debug("Scheduling screen %s", ui_screen)
         screen = ScreenData(ui_screen, args)
         self._screen_stack.add_first(screen)
+        self._redraw_on_first_scheduled_screen()
+
+    def _redraw_on_first_scheduled_screen(self):
+        if not self._first_screen_scheduled:
+            self.redraw()
+            self._first_screen_scheduled = True
 
     def replace_screen(self, ui_screen, args=None):
         """Schedules a screen to replace the current one.

--- a/tests/render_screen_test.py
+++ b/tests/render_screen_test.py
@@ -114,7 +114,8 @@ class SimpleUIScreenProcessing_TestCase(unittest.TestCase):
 
     def test_running_empty_loop(self, _):
         App.initialize()
-        App.run()
+        loop = App.get_event_loop()
+        loop.process_signals()
 
     def test_screen_event_loop_processing_with_two_screens(self, _):
         first_screen = EmptyScreen()


### PR DESCRIPTION
The redraw signal was enqueued when instantiating `ScreenScheduler`. Which caused exception when the `process_signals()` method was called with empty screen stack.