### PR TITLE
Add edit screens

### DIFF
--- a/simpleline/render/adv_widgets.py
+++ b/simpleline/render/adv_widgets.py
@@ -148,14 +148,13 @@ class YesNoDialog(UIScreen):
 class HelpScreen(UIScreen):
     """Screen to display a help message."""
 
-    title = N_("Help")
-
     def __init__(self, help_path):
         """
         :param help_path: help file name
         :type help_path: str
         """
         super().__init__()
+        self.title = N_("Help")
         self.help_path = help_path
 
     def refresh(self, args=None):

--- a/simpleline/render/adv_widgets.py
+++ b/simpleline/render/adv_widgets.py
@@ -21,6 +21,7 @@ import sys
 
 from simpleline import App
 from simpleline.render import widgets
+from simpleline.render.containers import WindowContainer
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen, InputState
 from simpleline.utils.i18n import _, N_, C_
@@ -175,3 +176,62 @@ class HelpScreen(UIScreen):
 
     def prompt(self, args=None):
         return Prompt(_("Press %s to return") % Prompt.ENTER)
+
+
+class GetInputScreen(UIScreen):
+    """Screen for getting user input."""
+
+    def __init__(self, message):
+        """
+        :param message: Prompt printed before user input.
+        :type message: str
+        """
+        super().__init__()
+        self._message = message
+        self._value = None
+        self._conditions = []
+
+    @property
+    def value(self):
+        """User input."""
+        return self._value
+
+    def add_acceptance_condition(self, acceptance_function, args=None):
+        """Add acceptance condition to the conditions list.
+
+        :param acceptance_function: Functions that accepts or rejects a user input.
+        :type acceptance_function: `function(input, args) -> bool`  - function which takes
+                                   user input (string) and arguments (`args`) and return True when input is accepted or
+                                   False if rejected so we will ask for a new input.
+
+        :param args: Second argument for `acceptance_function` the first one will be user input.
+        :type args: Anything.
+        """
+        self._conditions.append((acceptance_function, args))
+
+    def clear_acceptance_conditions(self):
+        """Clear list of the acceptance conditions."""
+        self._conditions.clear()
+
+    def refresh(self, args=None):
+        super().refresh(args)
+        self._window = WindowContainer()
+
+    def prompt(self, args=None):
+        return Prompt(message=self._message)
+
+    def input(self, args, key):
+        if not self._test_input(key):
+            return InputState.DISCARDED
+
+        self._value = key
+        self.close()
+
+        return InputState.PROCESSED
+
+    def _test_input(self, key):
+        for f, args in self._conditions:
+            if not f(key, args):
+                return False
+
+        return True

--- a/simpleline/render/adv_widgets.py
+++ b/simpleline/render/adv_widgets.py
@@ -235,3 +235,11 @@ class GetInputScreen(UIScreen):
                 return False
 
         return True
+
+
+class GetPasswordInputScreen(GetInputScreen):
+    """Screen for getting user password input."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.hide_user_input = True

--- a/simpleline/render/io_manager.py
+++ b/simpleline/render/io_manager.py
@@ -112,8 +112,10 @@ class InOutManager(object):
         """
         # get the widget tree from the screen and show it in the screen
         try:
-            # separate the content on the screen from the stuff we are about to display now
-            print(self._spacer)
+            if not active_screen.ui_screen.no_separator:
+                # separate the content on the screen from the stuff we are about to display now
+                print(self._spacer)
+
             # print UIScreen content
             active_screen.ui_screen.show_all()
         except ExitMainLoop:

--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -48,6 +48,9 @@ class UIScreen(SignalHandler):
         self._screen_height = screen_height
         self._screen_ready = False
 
+        # do not print separator for this screen
+        self._no_separator = False
+
         # list that holds the content to be printed out
         self._window = WindowContainer(self.title)
 
@@ -94,6 +97,24 @@ class UIScreen(SignalHandler):
     def input_required(self, input_required):
         """Set if the screen should require input."""
         self._input_required = input_required
+
+    @property
+    def no_separator(self):
+        """Should we print separator for this screen?
+
+        :returns: True to print separator before this screen.
+                  False do not print separator.
+        """
+        return self._no_separator
+
+    @no_separator.setter
+    def no_separator(self, no_separator):
+        """Print or do not print separator.
+
+        :param no_separator: Specify if the separator should be printed.
+        :type no_separator: bool
+        """
+        self._no_separator = no_separator
 
     @property
     def window(self):

--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -48,6 +48,9 @@ class UIScreen(SignalHandler):
         self._screen_height = screen_height
         self._screen_ready = False
 
+        # ask for password
+        self._hide_user_input = False
+
         # do not print separator for this screen
         self._no_separator = False
 
@@ -102,7 +105,7 @@ class UIScreen(SignalHandler):
     def no_separator(self):
         """Should we print separator for this screen?
 
-        :returns: True to print separator before this screen.
+        :returns: True to print separator before this screen (default).
                   False do not print separator.
         """
         return self._no_separator
@@ -112,9 +115,30 @@ class UIScreen(SignalHandler):
         """Print or do not print separator.
 
         :param no_separator: Specify if the separator should be printed.
-        :type no_separator: bool
+        :type no_separator: bool (default: False).
         """
         self._no_separator = no_separator
+
+    @property
+    def hide_user_input(self):
+        """Hide typed user input.
+
+        This is main solution how to ask for password.
+
+        :returns: True if user input should be hidden.
+                  False otherwise (default).
+        """
+        return self._hide_user_input
+
+    @hide_user_input.setter
+    def hide_user_input(self, hide_input):
+        """Should be the user input hidden.
+
+        :param hide_input: True if user input should be hidden.
+                          False if not (default).
+        :type hide_input: bool (default: False).
+        """
+        self._hide_user_input = hide_input
 
     @property
     def window(self):

--- a/simpleline/render/screen/__init__.py
+++ b/simpleline/render/screen/__init__.py
@@ -177,6 +177,9 @@ class UIScreen(SignalHandler):
         lines = widget.get_lines()
         num_lines = len(lines)
 
+        if num_lines == 0:
+            return
+
         prompt_height = 2
         real_screen_height = self._screen_height - prompt_height
 

--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -254,8 +254,9 @@ class ScreenScheduler(object):
         top_screen = self._get_last_screen()
         ui_screen = top_screen.ui_screen
         prompt = ui_screen.prompt(top_screen.args)
+        hide_user_input = ui_screen.hide_user_input
 
-        self._io_manager.get_user_input_async(prompt, self._process_input)
+        self._io_manager.get_user_input_async(prompt, self._process_input, hidden=hide_user_input)
 
     def _process_input(self, user_input):
         active_screen = self._get_last_screen()

--- a/simpleline/render/widgets.py
+++ b/simpleline/render/widgets.py
@@ -265,6 +265,42 @@ class TextWidget(Widget):
         self.write(self._text, width=width, wordwrap=True)
 
 
+class EntryWidget(TextWidget):
+    """This is the easy way how to generate entry items for containers.
+
+    If the numbering in a container is turned on the output looks like:
+
+    N) title
+       value
+
+    Without numbering turned on:
+
+    title
+    value
+    """
+
+    def __init__(self, title, value=None):
+        """ Create Entry widget instance.
+
+        :param title: Title of this entry.
+        :type title: String.
+
+        :param value: Actual value printed in second line below the title.
+        :type value: String.
+        """
+        text = self._create_text(title=title, value=value)
+        super().__init__(text)
+
+    def _create_text(self, title, value):
+        msg = title
+
+        if value:
+            msg += "\n"
+            msg += value
+
+        return msg
+
+
 class SeparatorWidget(Widget):
     """Print empty line."""
 

--- a/tests/simpleline_tests/adv_widgets_test.py
+++ b/tests/simpleline_tests/adv_widgets_test.py
@@ -24,7 +24,7 @@ from io import StringIO
 
 from tests.simpleline_tests import UtilityMixin
 
-from simpleline.render.adv_widgets import GetInputScreen
+from simpleline.render.adv_widgets import GetInputScreen, GetPasswordInputScreen
 
 
 @patch('simpleline.render.io_manager.InOutManager._get_input')
@@ -78,6 +78,31 @@ class AdvWidgets_TestCase(unittest.TestCase, UtilityMixin):
 
         self.assertEqual(expected_output, stdout_mock.getvalue())
         self.assertTrue(self.args_used)
+
+    @patch("getpass.getpass")
+    def test_getpass(self, hiden_stdin_mock, stdout_mock, stdin_mock):
+        prompt = "Type input"
+        input_text = "user input"
+        screen = GetPasswordInputScreen(message=prompt)
+        hiden_stdin_mock.return_value = input_text
+
+        self.schedule_screen_and_run(screen)
+
+        self.assertEqual(screen.value, input_text)
+
+    @patch("getpass.getpass")
+    def test_getpass_with_condition(self, hiden_stdin_mock, stdout_mock, stdin_mock):
+        prompt = "Type input"
+        wrong_input = "wrong"
+        condition = lambda x, _: x != wrong_input
+        hiden_stdin_mock.side_effect = self.input_generator()
+
+        screen = GetPasswordInputScreen(message=prompt)
+        screen.add_acceptance_condition(condition)
+
+        self.schedule_screen_and_run(screen)
+
+        self.assertTrue(self.correct_input)
 
     def input_generator(self):
         for i in ("wrong", "correct"):

--- a/tests/simpleline_tests/adv_widgets_test.py
+++ b/tests/simpleline_tests/adv_widgets_test.py
@@ -1,0 +1,91 @@
+# Advanced widgets test cases.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import unittest
+from unittest.mock import patch
+
+from io import StringIO
+
+from tests.simpleline_tests import UtilityMixin
+
+from simpleline.render.adv_widgets import GetInputScreen
+
+
+@patch('simpleline.render.io_manager.InOutManager._get_input')
+@patch('sys.stdout', new_callable=StringIO)
+class AdvWidgets_TestCase(unittest.TestCase, UtilityMixin):
+    def setUp(self):
+        self.correct_input = False
+        self.args_used = False
+
+    def test_gettext(self, stdout_mock, stdin_mock):
+        prompt = "Type input"
+        input_text = "user input"
+        screen = GetInputScreen(message=prompt)
+        stdin_mock.return_value = input_text
+
+        self.schedule_screen_and_run(screen)
+
+        expected_output = self.create_output_with_separators(["%s: " % prompt]).rstrip('\n')
+
+        self.assertEqual(expected_output, stdout_mock.getvalue())
+        self.assertEqual(screen.value, input_text)
+
+    def test_gettext_with_condition(self, stdout_mock, stdin_mock):
+        prompt = "Type input"
+        wrong_input = "wrong"
+        condition = lambda x, _: x != wrong_input
+        stdin_mock.side_effect = self.input_generator()
+
+        screen = GetInputScreen(message=prompt)
+        screen.add_acceptance_condition(condition)
+
+        self.schedule_screen_and_run(screen)
+
+        expected_output = self.create_output_with_separators(["%s: %s: " % (prompt, prompt)]).rstrip("\n")
+
+        self.assertEqual(expected_output, stdout_mock.getvalue())
+        self.assertTrue(self.correct_input)
+
+    def test_gettext_with_condition_and_use_arg(self, stdout_mock, stdin_mock):
+        prompt = "Type input"
+        user_input = "y"
+        stdin_mock.return_value = user_input
+
+        screen = GetInputScreen(message=prompt)
+        screen.add_acceptance_condition(self.acceptance_condition_test, "y")
+
+        self.schedule_screen_and_run(screen)
+
+        expected_msg = "%s: " % prompt
+        expected_output = self.create_output_with_separators([expected_msg]).rstrip("\n")
+
+        self.assertEqual(expected_output, stdout_mock.getvalue())
+        self.assertTrue(self.args_used)
+
+    def input_generator(self):
+        for i in ("wrong", "correct"):
+            if i == "correct":
+                self.correct_input = True
+            yield i
+
+    def acceptance_condition_test(self, user_input, args):
+        if user_input == args:
+            self.args_used = True
+        return True

--- a/tests/simpleline_tests/render_screen_test.py
+++ b/tests/simpleline_tests/render_screen_test.py
@@ -257,7 +257,7 @@ class InputProcessing_TestCase(unittest.TestCase):
         App.get_scheduler().io_manager.get_user_input(prompt=prompt, hidden=True)
 
         self.assertTrue(self.pass_called)
-        self.assertEqual(self.pass_prompt, prompt)
+        self.assertEqual(self.pass_prompt.rstrip(), str(prompt))
 
 
 # HELPER CLASSES

--- a/tests/simpleline_tests/render_screen_test.py
+++ b/tests/simpleline_tests/render_screen_test.py
@@ -53,7 +53,7 @@ class SeparatorPrinting_TestCase(unittest.TestCase, UtilityMixin):
 
         self.assertEqual(self.calculate_separator(width), stdout_mock.getvalue())
 
-    def test_no_separator(self, stdout_mock):
+    def test_zero_width_no_separator(self, stdout_mock):
         ui_screen = EmptyScreen()
         width = 0
 
@@ -72,6 +72,17 @@ class SeparatorPrinting_TestCase(unittest.TestCase, UtilityMixin):
         App.run()
 
         self.assertEqual("", stdout_mock.getvalue())
+
+    def test_no_separator(self, stdout_mock):
+        print_text = "testing"
+        screen = NoSeparatorScreen(print_text)
+
+        self.schedule_screen_and_run(screen)
+        self.schedule_screen_and_run(screen)
+
+        expected_output = print_text + "\n" + print_text + "\n"
+
+        self.assertEqual(expected_output, stdout_mock.getvalue())
 
 
 class SimpleUIScreenFeatures_TestCase(unittest.TestCase):
@@ -334,6 +345,19 @@ class FailedSetupScreen(UIScreen):
     def setup(self, args):
         super().setup(args)
         return False
+
+
+class NoSeparatorScreen(UIScreen):
+
+    def __init__(self, print_string):
+        super().__init__()
+        self.input_required = False
+        self.no_separator = True
+        self._print_string = print_string
+
+    def show_all(self):
+        print(self._print_string)
+        self.close()
 
 
 class NoInputScreen(UIScreen):

--- a/tests/simpleline_tests/widgets_test.py
+++ b/tests/simpleline_tests/widgets_test.py
@@ -25,7 +25,8 @@ from unittest.mock import patch
 from simpleline import App
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import UIScreen
-from simpleline.render.widgets import TextWidget, SeparatorWidget, CheckboxWidget, CenterWidget, ColumnWidget
+from simpleline.render.widgets import TextWidget, SeparatorWidget, CheckboxWidget, CenterWidget, ColumnWidget, \
+                                      EntryWidget
 
 
 class BaseWidgets_TestCase(unittest.TestCase):
@@ -197,6 +198,42 @@ class Widgets_TestCase(BaseWidgets_TestCase):
         expected_result = [u"   Test"]
 
         self.evaluate_result(w.get_lines(), expected_result)
+
+    def test_entry_widget(self):
+        title = "Title"
+        value = "Value"
+        w = EntryWidget(title=title, value=value)
+
+        w.render(30)
+
+        expected_result = [title,
+                           value]
+
+        self.evaluate_result(w.get_lines(), expected_result)
+
+    def test_entry_too_long(self):
+        title = "Title too long"
+        value = "Value also too long"
+        w = EntryWidget(title=title, value=value)
+
+        w.render(10)
+
+        expected_result = [u"Title too",
+                           u"long",
+                           u"Value also",
+                           u"too long"]
+
+        self.evaluate_result(w.get_lines(), expected_result)
+
+    def test_entry_value_empty(self):
+        title = "Title"
+        w = EntryWidget(title=title)
+
+        w.render(20)
+
+        expected_result = [title]
+
+        self.evaluate_result(w.get_lines(), expected_result=expected_result)
 
 
 @patch('simpleline.render.io_manager.InOutManager._get_input')


### PR DESCRIPTION
Add `GetInputScreen` and `GetPassInputScreen` for getting user input.

To enable support for the screens the UIScreen class was extended by these features:
* `no_separator` - do not print separator before screen
* `hiden_user_input` - hide user input (sensitive user input)


Also small fix in `HelpScreen` and calling of `getpass` function.