### PR TITLE
Robust zanata check in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ potfile:
 	$(MAKE) -C po potfile
 
 po-pull:
-	rpm -q zanata-python-client &>/dev/null || ( echo "need to run: dnf install zanata-python-client"; exit 1 )
+	which zanata &>/dev/null || ( echo "need to install zanata python client"; exit 1 )
 	zanata pull $(ZANATA_PULL_ARGS)
 
 po-push: potfile


### PR DESCRIPTION
The zanata package renamed between F28 and F27 which makes this check valid only for F28 and later. This commit makes the check able to work independent on package name; it just checks the binary.

Also this will make packaging for other distributions easier.