### PR TITLE
Setup logging handler properly for a library

### DIFF
--- a/simpleline/__init__.py
+++ b/simpleline/__init__.py
@@ -22,6 +22,11 @@
 __all__ = ["App"]
 
 
+from simpleline.logging import setup_logging
+
+setup_logging()
+
+
 class App(object):
     """This is the main class for Simpleline library.
 

--- a/simpleline/logging.py
+++ b/simpleline/logging.py
@@ -26,6 +26,13 @@ import logging
 SIMPLELINE_LOGGER = "simpleline"
 
 
+def setup_logging():
+    """Set proper logging for a library"""
+    log = get_simpleline_logger()
+    null_hd = logging.NullHandler()
+    log.addHandler(null_hd)
+
+
 def get_simpleline_logger():
     """Return logging instance that can be used in the application."""
     return logging.getLogger(SIMPLELINE_LOGGER)


### PR DESCRIPTION
The logging settings can't be changed once it is configured. This is especially bad in case of library. Use `NullHandler` which is recommended by Python 3 documentation.

https://docs.python.org/3/howto/logging.html#library-config