### PR TITLE
Enable packit auto release to Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,7 @@ jobs:
   - job: propose_downstream
     trigger: release
     metadata:
-      dist-git-branch: fedora-all
+      dist-git-branch: fedora-development
 
   - job: tests
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,7 @@ jobs:
   - job: propose_downstream
     trigger: release
     metadata:
-      dist-git-branch: fedora-development
+      dist_git_branches: fedora-development
 
   - job: tests
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,6 @@
 specfile_path: python-simpleline.spec
 upstream_package_name: simpleline
+upstream_tag_template: simpleline-{version}
 actions:
   get-current-version:
     - "python3 ./setup.py --version"

--- a/python-simpleline.spec
+++ b/python-simpleline.spec
@@ -8,7 +8,7 @@ Release: 1%{?dist}
 # This tarball was created from upstream git:
 #   git clone https://github.com/rhinstaller/python-simpleline
 #   cd python-simpleline && make archive
-Source0: https://github.com/rhinstaller/python-%{srcname}/archive/%{srcname}-%{version}.tar.gz
+Source0: https://github.com/rhinstaller/python-%{srcname}/releases/download/%{srcname}-%{version}/%{srcname}-%{version}.tar.gz
 
 License: LGPLv3+
 BuildArch: noarch


### PR DESCRIPTION
Packit should create a downstream release pull request when a new upstream release is created.