### PR TITLE
[.packit.yaml] Remove 'bash -c' from create-archive action

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,8 +6,8 @@ actions:
     - "python3 ./setup.py --version"
   create-archive:
     - "make BUILD_ARGS=sdist archive"
-    - 'bash -c "cp dist/*.tar.gz ."'
-    - 'bash -c "ls *.tar.gz"'
+    - 'cp dist/*.tar.gz .'
+    - 'ls *.tar.gz'
 jobs:
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
See https://github.com/packit-service/packit/pull/871 and https://github.com/packit-service/packit/issues/905

You'll need this once you start using packit-0.13.x ([currently in testing](https://bodhi.fedoraproject.org/updates/?packages=packit))