### PR TITLE
Use relative imports in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 
 test:
 	@echo "*** Running unittests ***"
-	PYTHONPATH=. $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
+	$(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 check:
 	@echo "*** Running pocketlint ***"

--- a/tests/simpleline_tests/adv_widgets_test.py
+++ b/tests/simpleline_tests/adv_widgets_test.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 
 from io import StringIO
 
-from tests.simpleline_tests import UtilityMixin
+from . import UtilityMixin
 
 from simpleline.render.adv_widgets import GetInputScreen, GetPasswordInputScreen
 

--- a/tests/simpleline_tests/containers_test.py
+++ b/tests/simpleline_tests/containers_test.py
@@ -25,7 +25,7 @@ from simpleline import App
 from simpleline.render.containers import WindowContainer, ListRowContainer, ListColumnContainer, KeyPattern
 from simpleline.render.screen import UIScreen, InputState
 from simpleline.render.widgets import TextWidget
-from tests.simpleline_tests.widgets_test import BaseWidgets_TestCase
+from .widgets_test import BaseWidgets_TestCase
 
 
 class Containers_TestCase(BaseWidgets_TestCase):

--- a/tests/simpleline_tests/glib_tests/event_loop_glib_test.py
+++ b/tests/simpleline_tests/glib_tests/event_loop_glib_test.py
@@ -17,8 +17,8 @@
 # Red Hat, Inc.
 #
 
-from tests.simpleline_tests.event_loop_test import ProcessEvents_TestCase
-from tests.simpleline_tests.glib_tests import GLibUtilityMixin
+from . import GLibUtilityMixin
+from ..event_loop_test import ProcessEvents_TestCase
 
 
 class GLibProcessEvents_TestCase(ProcessEvents_TestCase, GLibUtilityMixin):

--- a/tests/simpleline_tests/glib_tests/input_handler_glib_test.py
+++ b/tests/simpleline_tests/glib_tests/input_handler_glib_test.py
@@ -18,8 +18,8 @@
 #
 
 
-from tests.simpleline_tests.input_handler_test import InputHandler_TestCase
-from tests.simpleline_tests.glib_tests import GLibUtilityMixin
+from . import GLibUtilityMixin
+from ..input_handler_test import InputHandler_TestCase
 
 
 class GLibInputHandler_TestCase(InputHandler_TestCase, GLibUtilityMixin):

--- a/tests/simpleline_tests/glib_tests/render_screen_glib_test.py
+++ b/tests/simpleline_tests/glib_tests/render_screen_glib_test.py
@@ -18,8 +18,8 @@
 #
 
 
-from tests.simpleline_tests.glib_tests import GLibUtilityMixin
-from tests.simpleline_tests.render_screen_test import SimpleUIScreenProcessing_TestCase, InputProcessing_TestCase, \
+from . import GLibUtilityMixin
+from ..render_screen_test import SimpleUIScreenProcessing_TestCase, InputProcessing_TestCase, \
                                                       ScreenException_TestCase
 
 

--- a/tests/simpleline_tests/glib_tests/screen_scheduler_glib_test.py
+++ b/tests/simpleline_tests/glib_tests/screen_scheduler_glib_test.py
@@ -18,8 +18,8 @@
 #
 
 
-from tests.simpleline_tests.glib_tests import GLibUtilityMixin
-from tests.simpleline_tests.screen_scheduler_test import ScreenScheduler_TestCase
+from . import GLibUtilityMixin
+from ..screen_scheduler_test import ScreenScheduler_TestCase
 
 
 class GLibScreenScheduler_TestCase(ScreenScheduler_TestCase, GLibUtilityMixin):

--- a/tests/simpleline_tests/render_screen_test.py
+++ b/tests/simpleline_tests/render_screen_test.py
@@ -25,7 +25,7 @@ from unittest import mock
 from simpleline import App
 from simpleline.render import RenderUnexpectedError
 from simpleline.render.screen import UIScreen, InputState
-from tests.simpleline_tests import UtilityMixin
+from . import UtilityMixin
 
 
 def _fake_input(queue_instance, prompt):

--- a/tests/simpleline_tests/screen_scheduler_test.py
+++ b/tests/simpleline_tests/screen_scheduler_test.py
@@ -23,7 +23,7 @@ from unittest import mock
 
 from simpleline.render.screen import UIScreen
 from simpleline.render.screen_handler import ScreenHandler
-from tests.simpleline_tests import UtilityMixin
+from . import UtilityMixin
 
 
 @mock.patch('sys.stdout', new_callable=StringIO)


### PR DESCRIPTION
Before we used `from tests... import` which is fine if you want to test code but complicating usage of testing installed library. Problem is that to import tests folder you have to start from the repository root which will also add simpleline folder with all the sources to `PYTHONPATH`.

By using relative imports and removing `tests/__init__.py` we can start tests from the `tests` folder. That will remove move `PYTHONPATH` to `tests` instead of repository root.

Resolves: rhbz#1682886