### PR TITLE
Remove packit get-current-action

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,8 +2,6 @@ specfile_path: python-simpleline.spec
 upstream_package_name: simpleline
 upstream_tag_template: simpleline-{version}
 actions:
-  get-current-version:
-    - "python3 ./setup.py --version"
   create-archive:
     - "make BUILD_ARGS=sdist archive"
     - 'bash -c "cp dist/*.tar.gz ."'


### PR DESCRIPTION
This is not required anymore thanks to this fix:

https://github.com/packit/packit/issues/867#event-3791693297

_Waiting until the change will be released._