### PR TITLE
Fix raise-missing-from (W0707) pylint warnings

### DIFF
--- a/simpleline/event_loop/event_queue.py
+++ b/simpleline/event_loop/event_queue.py
@@ -136,8 +136,8 @@ class EventQueue():
             # pylint: disable=not-context-manager
             with self._lock:
                 self._contained_screens.remove(signal_source)
-        except KeyError:
-            raise EventQueueError("Can't remove non-existing event source!")
+        except KeyError as e:
+            raise EventQueueError("Can't remove non-existing event source!") from e
 
     def contains_source(self, signal_source):
         """Test if `signal_source` belongs to this queue.

--- a/simpleline/event_loop/main_loop.py
+++ b/simpleline/event_loop/main_loop.py
@@ -124,7 +124,7 @@ class MainLoop(AbstractEventLoop):
                 self._active_queue = self._event_queues[-1]
             except IndexError:
                 log.error("No more event queues to work with!")
-                raise ExitMainLoop()
+                raise ExitMainLoop()  # pylint: disable=raise-missing-from
 
         self._run_loop = False
 

--- a/simpleline/render/screen_scheduler.py
+++ b/simpleline/render/screen_scheduler.py
@@ -131,9 +131,9 @@ class ScreenScheduler():
         log.debug("Replacing screen %s", ui_screen)
         try:
             execute_new_loop = self._screen_stack.pop().execute_new_loop
-        except ScreenStackEmptyException:  # pylint: disable=try-except-raise
+        except ScreenStackEmptyException as e:
             raise ScreenStackEmptyException("Switch screen is not possible when there is no "
-                                            "screen scheduled!")
+                                            "screen scheduled!") from e
 
         # we have to keep the old_loop value so we stop
         # dialog's mainloop if it ever uses switch_screen
@@ -305,7 +305,7 @@ class ScreenScheduler():
                             raise ExitMainLoop()
 
                         self.redraw()
-                    except AttributeError:
-                        raise ExitMainLoop()
+                    except AttributeError as e:
+                        raise ExitMainLoop() from e
                 else:
                     raise ExitMainLoop()

--- a/simpleline/render/screen_stack.py
+++ b/simpleline/render/screen_stack.py
@@ -73,7 +73,7 @@ class ScreenStack():
 
             return self._screens[-1]
         except IndexError as e:
-            raise ScreenStackEmptyException(e)
+            raise ScreenStackEmptyException(e) from e
 
     def add_first(self, screen):
         """Add `screen` to the bottom of the stack.


### PR DESCRIPTION
Use `raise from` where appropriate. Silence the warning for the
ScreenScheduler class where it exits the main loop, as that is not
really exception propagation.