### PR TITLE
Add fedora-eln for build and test execution

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,3 +17,9 @@ jobs:
     metadata:
       targets:
         - fedora-all
+
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-eln


### PR DESCRIPTION
This will enable us that we won't break future RHEL branching.