### PR TITLE
Use Fedora container registry instead of Dockerhub

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ jobs:
   rawhide:
     runs-on: ubuntu-latest
     container:
-      image: docker.io/fedora:rawhide
+      image: registry.fedoraproject.org/fedora:rawhide
     steps:
       - name: Clone repository
         uses: actions/checkout@v2


### PR DESCRIPTION
First, they are more up to date so we will avoid issue with bad GPG keys we have now.
Second, there is no limit for downloads.