### PR TITLE
Add missing make command to spec file

### DIFF
--- a/python-simpleline.spec
+++ b/python-simpleline.spec
@@ -12,6 +12,7 @@ Source0: https://github.com/rhinstaller/python-%{srcname}/releases/download/%{sr
 
 License: LGPLv3+
 BuildArch: noarch
+BuildRequires: make
 BuildRequires: python3-devel
 BuildRequires: gettext
 BuildRequires: python3-setuptools


### PR DESCRIPTION
The make was removed from build-roots from F34 further. So we need to add it manually.