### PR TITLE
Improve tag naming of this project

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,5 @@
 specfile_path: python-simpleline.spec
 upstream_package_name: simpleline
-upstream_tag_template: simpleline-{version}
 actions:
   create-archive:
     - "make BUILD_ARGS=sdist archive"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PKGNAME=simpleline
 SPECNAME=python-$(PKGNAME)
 VERSION=$(shell awk '/Version:/ { print $$2 }' $(SPECNAME).spec)
 RELEASE=$(shell awk '/Release:/ { print $$2 }' $(SPECNAME).spec | sed -e 's|%.*$$||g')
-TAG=$(PKGNAME)-$(VERSION)
+TAG=$(VERSION)
 
 PYTHON?=python3
 COVERAGE?=coverage3


### PR DESCRIPTION
Tag will be named just by version, e.g. `1.8.1`. The `simpleline-1.8.1` prefix will not be used anymore.
That is the standard versioning. No need to add the prefix which only giving us problems everywhere.

Related to https://github.com/rhinstaller/python-simpleline/issues/102.