### PR TITLE
Do not force using f-strings by pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,6 +73,7 @@ disable=duplicate-code,
         unnecessary-pass,
         unused-argument,
         useless-return,
+        consider-using-f-string,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
New warning introduced around pylint 2.11.1.