### PR TITLE
Remove pocketlint from the build requires

### DIFF
--- a/python-simpleline.spec
+++ b/python-simpleline.spec
@@ -16,7 +16,6 @@ BuildRequires: python3-devel
 BuildRequires: gettext
 BuildRequires: python3-setuptools
 BuildRequires: intltool
-BuildRequires: python3-pocketlint
 BuildRequires: python3-gobject-base
 
 %description


### PR DESCRIPTION
It's not a build require at all.