### PR TITLE
Add Makefile target for local container tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,4 @@ jobs:
 
       - name: Run test
         run: |
-          podman run --rm -v .:/simpleline:Z --workdir /simpleline registry.fedoraproject.org/fedora:rawhide sh -c " \
-              dnf install -y python3-pylint python3-gobject-base make; \
-              make ci"
+          make container-ci

--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,9 @@ pypi-upload:
 
 .PHONY: ci
 ci: check test
+
+# Run tests in the container but with fixed pylint version
+container-ci:
+	podman run --pull=always --rm -v .:/simpleline:Z --workdir /simpleline quay.io/centos/centos:stream9 sh -c " \
+	dnf install -y python3-pip python3-gobject-base make && pip3 install pocketlint 'pylint==2.8.3' ; \
+	make ci"


### PR DESCRIPTION
It is a small wrapper to run tests in a container with a pinned pylint version.

The pinned pylint version is required otherwise we would be still fixing pylint issues on this stable branch.

Use this new call also in the GH action.