### PR TITLE
Enable packit builds for centos-stream-9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,45 +1,21 @@
 specfile_path: python-simpleline.spec
 upstream_package_name: simpleline
+
 actions:
   create-archive:
     - "make BUILD_ARGS=sdist archive"
     - 'bash -c "cp dist/*.tar.gz ."'
     - 'bash -c "ls *.tar.gz"'
+
 jobs:
-  - job: propose_downstream
-    trigger: release
-    metadata:
-      dist_git_branches: fedora-development
-
-  - job: tests
-    trigger: pull_request
-    metadata:
-      targets:
-        - fedora-all
-
   - job: copr_build
     trigger: pull_request
-    metadata:
-      targets:
-        - fedora-eln
+    branch: "1.8"
+    targets:
+      - centos-stream-9
 
   - job: copr_build
     trigger: commit
-    metadata:
-      targets:
-        - fedora-rawhide
-        - fedora-eln
-      branch: master
-      owner: "@rhinstaller"
-      project: Anaconda
-      preserve_project: True
-
-  - job: copr_build
-    trigger: commit
-    metadata:
-      targets:
-        - fedora-latest
-      branch: master
-      owner: "@rhinstaller"
-      project: Anaconda-devel
-      preserve_project: True
+    branch: "1.8"
+    targets:
+      - centos-stream-9


### PR DESCRIPTION
This stable branch is released on centos-stream-9 so lets test the build there.