### PR TITLE
Enable CentOS Stream 8 builds for 1.1 branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,21 @@
+specfile_path: python-simpleline.spec
+upstream_package_name: simpleline
+
+actions:
+  create-archive:
+    - "make BUILD_ARGS=sdist archive"
+    - 'bash -c "cp dist/*.tar.gz ."'
+    - 'bash -c "ls *.tar.gz"'
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    branch: "1.1"
+    targets:
+      - centos-stream-8
+
+  - job: copr_build
+    trigger: commit
+    branch: "1.1"
+    targets:
+      - centos-stream-8


### PR DESCRIPTION
This stable branch is released on CentOS Stream 8 so let's test builds there.