### PR TITLE
fix: use blocking GLib main context iteration to prevent CPU busy-spin

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,6 +20,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
+      - fedora-rawhide
       - fedora-eln
 
   - job: copr_build

--- a/simpleline/event_loop/glib_event_loop.py
+++ b/simpleline/event_loop/glib_event_loop.py
@@ -43,8 +43,9 @@ __all__ = ["GLibEventLoop"]
 
 class GLibEventLoop(AbstractEventLoop):
 
-    def __init__(self):
+    def __init__(self, blocking=True):
         super().__init__()
+        self._blocking = blocking
         # Create first loop
         loop = GLib.MainLoop()
         self._event_loops = [EventLoopData(loop)]
@@ -208,12 +209,9 @@ class GLibEventLoop(AbstractEventLoop):
         else:
             self._iterate_event_loop(loop_data.loop)
 
-    @staticmethod
-    def _iterate_event_loop(event_loop):
+    def _iterate_event_loop(self, event_loop):
         context = event_loop.get_context()
-        # This is useful for tests
-        wait_on_timeout = False
-        context.iteration(wait_on_timeout)
+        context.iteration(self._blocking)
 
 
 class EventLoopData():

--- a/tests/units/glib/__init__.py
+++ b/tests/units/glib/__init__.py
@@ -42,7 +42,7 @@ class GLibUtilityMixin():
     def create_glib_loop(self):
         # clear flags
         self.timeout_error = False
-        self.loop = GLibEventLoop()
+        self.loop = GLibEventLoop(blocking=False)
 
         loop = self.loop.active_main_loop
         context = loop.get_context()


### PR DESCRIPTION
GLibEventLoop._iterate_event_loop was calling context.iteration(False), which returns immediately when no events are pending. When process_signals(return_after=...) loops waiting for a signal that takes minutes to arrive (e.g. installation completion in anaconda TUI), this causes a 100% CPU busy-spin.

Change the default to blocking iteration (may_block=True) so the GLib context sleeps until a source fires. Add a blocking parameter to the constructor so tests can opt into non-blocking mode.

Resolves: rhbz#2344225

I was able to reproduce the linked bug:

Before: 
<img width="1146" height="716" alt="Screenshot 2026-07-20 at 09-09-31 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/dd3881a8-125a-47b3-83a3-af7289fc9ad6" />


With fix: 
<img width="1146" height="716" alt="Screenshot 2026-07-20 at 09-04-22 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/c0748d6d-3707-49b1-8bd8-45e28a1df3dd" />
